### PR TITLE
fix: Sort file name length if same directory

### DIFF
--- a/src/sign.ts
+++ b/src/sign.ts
@@ -189,11 +189,16 @@ async function signApplication (opts: ValidatedSignOptions, identity: Identity) 
   /**
    * Sort the child paths by how deep they are in the file tree.  Some arcane apple
    * logic expects the deeper files to be signed first otherwise strange errors get
-   * thrown our way
+   * thrown our way (This also includes files with longer names)
    */
   children.sort((a, b) => {
-    const aDepth = a.split(path.sep).length;
-    const bDepth = b.split(path.sep).length;
+    const aList = a.split(path.sep);
+    const bList = b.split(path.sep);
+    const aDepth = aList.length;
+    const bDepth = bList.length;
+    if (bDepth - aDepth === 0) {
+      return bList[bDepth - 1].length - aList[aDepth - 1].length;
+    }
     return bDepth - aDepth;
   });
 

--- a/src/sign.ts
+++ b/src/sign.ts
@@ -196,10 +196,17 @@ async function signApplication (opts: ValidatedSignOptions, identity: Identity) 
     const bList = b.split(path.sep);
     const aDepth = aList.length;
     const bDepth = bList.length;
-    if (bDepth - aDepth === 0) {
-      return bList[bDepth - 1].length - aList[aDepth - 1].length;
+    if (bDepth - aDepth !== 0) {
+      return bDepth - aDepth;
     }
-    return bDepth - aDepth;
+    const aVal = aList[aDepth - 1];
+    const bVal = bList[bDepth - 1];
+    const aLength = aVal.length;
+    const bLength = bVal.length;
+    if (bLength - aLength !== 0) {
+      return bLength - aLength;
+    }
+    return bVal.localeCompare(aVal);
   });
 
   for (const filePath of [...children, opts.app]) {


### PR DESCRIPTION
I just had this issue where my app would not sign. I am adding a couple of extra binaries to the `Contents/MacOS` directory. The file names happened to be longer than the application name. I spent two days trying to figure out why these files wouldn't sign.

This was my solution and it seems to work well.