### PR TITLE
Sign with --deep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,21 +28,21 @@ version: 2
 jobs:
   test-mac-16:
     macos:
-      xcode: "11.6.0"
+      xcode: "11.7.0"
     environment:
       NODE_VERSION: "16"
     <<: *steps-test
 
   test-mac-14:
     macos:
-      xcode: "11.6.0"
+      xcode: "11.7.0"
     environment:
       NODE_VERSION: "14"
     <<: *steps-test
 
   test-mac-12:
     macos:
-      xcode: "11.6.0"
+      xcode: "11.7.0"
     environment:
       NODE_VERSION: "12"
     <<: *steps-test

--- a/src/sign.ts
+++ b/src/sign.ts
@@ -181,7 +181,7 @@ async function signApplication (opts: ValidatedSignOptions, identity: Identity) 
 
   if (opts.binaries) children.push(...opts.binaries);
 
-  const args = ['--sign', identity.hash || identity.name, '--force'];
+  const args = ['--sign', identity.hash || identity.name, '--force', '--deep'];
   if (opts.keychain) {
     args.push('--keychain', opts.keychain);
   }


### PR DESCRIPTION
I have some additional binaries which I need to include into the app bundle, but one of them has dynamically linked libs and verification always fails with "code object is not signed at all" error for those libs unless `--deep` option is used when signing.
I also tried pre-signing those binaries with `--deep` and then adding them to `extraFiles` as well as `signIgnore` sections in electron-builder config to no avail. Same error when verifying signed bundle. Note that signing is currently done without `--deep` option while verification _uses_ `--deep`. So there's a bit of a mismatch there 🙂

Closes #240.