### PR TITLE
ci: update xcode and node versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,30 +26,31 @@ steps-test: &steps-test
 
 version: 2
 jobs:
+  test-mac-18:
+    macos:
+      xcode: "13.3.0"
+    environment:
+      NODE_VERSION: "18"
+    <<: *steps-test
+
   test-mac-16:
     macos:
-      xcode: "11.6.0"
+      xcode: "13.3.0"
     environment:
       NODE_VERSION: "16"
     <<: *steps-test
 
   test-mac-14:
     macos:
-      xcode: "11.6.0"
+      xcode: "13.3.0"
     environment:
       NODE_VERSION: "14"
     <<: *steps-test
 
-  test-mac-12:
-    macos:
-      xcode: "11.6.0"
-    environment:
-      NODE_VERSION: "12"
-    <<: *steps-test
 workflows:
   version: 2
   test:
     jobs:
+      - test-mac-18
       - test-mac-16
       - test-mac-14
-      - test-mac-12


### PR DESCRIPTION
Two things here:

1. The build is failing because `Job was rejected because resource class medium, image xcode:11.6.0 is not a valid resource class`. This image was removed from the platform earlier this year: https://discuss.circleci.com/t/xcode-image-deprecation/44294
2. Node 18 is hitting LTS in 2 weeks. This adds a Node 18 CI job and removes the Node 12 one as that versions is slated for deprecation.