### PR TITLE
fix: export `SignOptions` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { sign, signApp } from './sign';
 import { flat, buildPkg } from './flat';
+import type { SignOptions } from './types';
 
 // TODO: Remove and leave only proper named exports, but for non-breaking change reasons
 // we need to keep this weirdness for now
@@ -12,3 +13,4 @@ module.exports.flatAsync = buildPkg;
 module.exports.buildPkg = buildPkg;
 
 export { sign, flat, signApp as signAsync, signApp, buildPkg as flatAsync, buildPkg };
+export type { SignOptions };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { sign, signApp } from './sign';
 import { flat, buildPkg } from './flat';
-import type { SignOptions } from './types';
 
 // TODO: Remove and leave only proper named exports, but for non-breaking change reasons
 // we need to keep this weirdness for now
@@ -13,4 +12,4 @@ module.exports.flatAsync = buildPkg;
 module.exports.buildPkg = buildPkg;
 
 export { sign, flat, signApp as signAsync, signApp, buildPkg as flatAsync, buildPkg };
-export type { SignOptions };
+export * from './types';


### PR DESCRIPTION
Hello,

I want to be able to import this type since I am calling some of the functions in this package.

I think this makes sense, especially since the sister-package `@electron/notarize` exports the `NotarizeOptions` type. https://github.com/electron/notarize/blob/11fcb0bc8ccb02a47c0a221f677b457f14d58fbf/src/index.ts
