### PR TITLE
fix(flat): use `pkgbuild` to bundle pre/postinstall scripts

### DIFF
--- a/src/flat.ts
+++ b/src/flat.ts
@@ -54,7 +54,6 @@ async function validateFlatOpts (opts: FlatOptions): Promise<ValidatedFlatOption
  * @returns {Promise} Promise.
  */
 async function buildApplicationPkg (opts: ValidatedFlatOptions, identity: Identity) {
-
   const componentPkgPath = path.join(path.dirname(opts.app), path.basename(opts.app, '.app') + '-component.pkg');
   const pkgbuildArgs = ['--install-location', opts.install, '--component', opts.app, componentPkgPath];
   if (opts.scripts) {

--- a/src/flat.ts
+++ b/src/flat.ts
@@ -54,16 +54,23 @@ async function validateFlatOpts (opts: FlatOptions): Promise<ValidatedFlatOption
  * @returns {Promise} Promise.
  */
 async function buildApplicationPkg (opts: ValidatedFlatOptions, identity: Identity) {
-  const args = ['--component', opts.app, opts.install, '--sign', identity.name, opts.pkg];
+
+  const componentPkgPath = path.join(path.dirname(opts.app), path.basename(opts.app, '.app') + '-component.pkg');
+  const pkgbuildArgs = ['--install-location', opts.install, '--component', opts.app, componentPkgPath];
+  if (opts.scripts) {
+    pkgbuildArgs.unshift('--scripts', opts.scripts);
+  }
+  debugLog('Building component package... ' + opts.app);
+  await execFileAsync('pkgbuild', pkgbuildArgs);
+
+  const args = ['--package', componentPkgPath, opts.install, '--sign', identity.name, opts.pkg];
   if (opts.keychain) {
     args.unshift('--keychain', opts.keychain);
-  }
-  if (opts.scripts) {
-    args.unshift('--scripts', opts.scripts);
   }
 
   debugLog('Flattening... ' + opts.app);
   await execFileAsync('productbuild', args);
+  await execFileAsync('rm', [componentPkgPath]);
 }
 
 /**


### PR DESCRIPTION
The `--scripts` should go to `pkgbuild` in order for preinstall and postinstall script to work. So the single `productbuild` command has to be separated into `pkgbuild` and `productbuild`.

I am not sure if the `--scripts` in `productbuild` has any practical use. Might need to add an new option if need to retain the `--scripts` for both `productbuild` and `pkgbuild`