### PR TITLE
fix: Serialize walkAsync so isBinaryFile doesn't throw EMFILE: too many open files.

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -136,33 +136,32 @@ export async function walkAsync (dirPath: string): Promise<string[]> {
   debugLog('Walking... ' + dirPath);
 
   async function _walkAsync (dirPath: string): Promise<DeepList<string>> {
+    const res: string[] = [];
     const children = await fs.readdir(dirPath);
-    return await Promise.all(
-      children.map(async (child) => {
-        const filePath = path.resolve(dirPath, child);
-
-        const stat = await fs.stat(filePath);
-        if (stat.isFile()) {
-          switch (path.extname(filePath)) {
-            case '.cstemp': // Temporary file generated from past codesign
-              debugLog('Removing... ' + filePath);
-              await fs.remove(filePath);
-              return null;
-            default:
-              return await getFilePathIfBinary(filePath);
-          }
-        } else if (stat.isDirectory() && !stat.isSymbolicLink()) {
-          const walkResult = await _walkAsync(filePath);
-          switch (path.extname(filePath)) {
-            case '.app': // Application
-            case '.framework': // Framework
-              walkResult.push(filePath);
-          }
-          return walkResult;
+    for (const child of children) {
+      const filePath = path.resolve(dirPath, child);
+      const stat = await fs.stat(filePath);
+      if (stat.isFile()) {
+        switch (path.extname(filePath)) {
+          case '.cstemp': // Temporary file generated from past codesign
+            debugLog('Removing... ' + filePath);
+            await fs.remove(filePath);
+            break;
+          default:
+            await getFilePathIfBinary(filePath) && res.push(filePath);
+            break;
         }
-        return null;
-      })
-    );
+      } else if (stat.isDirectory() && !stat.isSymbolicLink()) {
+        const walkResult = await _walkAsync(filePath);
+        switch (path.extname(filePath)) {
+          case '.app': // Application
+          case '.framework': // Framework
+            walkResult.push(filePath);
+        }
+        res.push(walkResult);
+      }
+    }
+    return res;
   }
 
   const allPaths = await _walkAsync(dirPath);


### PR DESCRIPTION
Hey! Thanks for the great library – ran into an issue and have a small fix proposal.

I know this has already been raised here: https://github.com/electron/osx-sign/issues/248

However, for #reasons we need to disable ASAR packaging for our product. This causes `walkAsync` to crawl all of `node_modules`. Because `getFilePathIfBinary` actually opens and reads the first few thousand bytes of every file, the recursive `Promise.all` would throw with `EMFILE: too many open files` no matter how high I set the open file limit via `ulimit`.

Conveniently, just putting things into a simple for loop fixes things by serializing the file reads, giving Node a chance to release each file before reading the next one. IIRC, this shouldn't impact performance much because of how Node's FS access works. Anecdotally, we also have this change deployed to our CI and it's performing very quickly without any errors!