### PR TITLE
build: do CFA releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,56 +1,69 @@
-step-restore-cache: &step-restore-cache
-  restore_cache:
-    keys:
-      - v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
-      - v1-dependencies-{{ arch }}
+version: 2.1
 
-steps-test: &steps-test
-  steps:
-    - checkout
-    - *step-restore-cache
-    - run:
-        name: Setup NVM
-        command: |
-          curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash -s -- --no-use
-          echo 'export NVM_DIR=$HOME/.nvm' >> $BASH_ENV
-          echo 'source $NVM_DIR/nvm.sh' >> $BASH_ENV
-          echo 'nvm install $NODE_VERSION' >> $BASH_ENV
-          echo 'nvm alias default $NODE_VERSION' >> $BASH_ENV
-    - run: yarn --frozen-lockfile
-    - save_cache:
-        paths:
-          - node_modules
-        key: v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
-    - run: ./test/ci/generate-identity.sh
-    - run: yarn build && yarn test
+orbs:
+  cfa: continuousauth/npm@1.0.2
+  node: circleci/node@5.1.0
 
-version: 2
+commands:
+  install:
+    parameters:
+      node-version:
+        description: Node.js version to install
+        type: string
+    steps:
+      - run: git config --global core.autocrlf input
+      - node/install:
+          node-version: << parameters.node-version >>
+      - run: nvm use << parameters.node-version >>
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
+            - v1-dependencies-{{ arch }}
+      - run: yarn install --frozen-lockfile
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
+  test:
+    steps:
+      - run: ./test/ci/generate-identity.sh
+      - run: yarn build && yarn test
+
 jobs:
-  test-mac-18:
+  test-mac:
     macos:
-      xcode: "13.3.0"
-    environment:
-      NODE_VERSION: "18"
-    <<: *steps-test
-
-  test-mac-16:
-    macos:
-      xcode: "13.3.0"
-    environment:
-      NODE_VERSION: "16"
-    <<: *steps-test
-
-  test-mac-14:
-    macos:
-      xcode: "13.3.0"
-    environment:
-      NODE_VERSION: "14"
-    <<: *steps-test
+      xcode: "14.0.0"
+    resource_class: macos.x86.medium.gen2
+    parameters:
+      node-version:
+        description: Node.js version to install
+        type: string
+    steps:
+      - install:
+          node-version: << parameters.node-version >>
+      - test
 
 workflows:
-  version: 2
-  test:
+  test_and_release:
+    # Run the test jobs first, then the release only when all the test jobs are successful
     jobs:
-      - test-mac-18
-      - test-mac-16
-      - test-mac-14
+      - test-mac:
+          matrix:
+            parameters:
+              node-version:
+                - 20.3.1
+                - 18.16.1
+                - 16.20.1
+                - 14.21.3
+      - cfa/release:
+          requires:
+            - test-mac-20.3.1
+            - test-mac-18.16.1
+            - test-mac-16.20.1
+            - test-mac-14.21.3
+          filters:
+            branches:
+              only:
+                - main
+          context: cfa-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   cfa: continuousauth/npm@1.0.2
-  node: electronjs/node@1.0.0
+  node: electronjs/node@1.1.0
 
 workflows:
   test_and_release:
@@ -16,6 +16,7 @@ workflows:
           test-steps:
             - run: ./test/ci/generate-identity.sh
             - run: yarn build && yarn test
+          use-test-steps: true
           matrix:
             alias: test-mac
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
     jobs:
       - node/test:
           executor: node/macos
-          name: test-<< matrix.executor >>-<< matrix.node-version >>
+          name: test-mac-<< matrix.node-version >>
           pre-steps:
             - run: git config --global core.autocrlf input
           test-steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,66 +2,31 @@ version: 2.1
 
 orbs:
   cfa: continuousauth/npm@1.0.2
-  node: circleci/node@5.1.0
-
-commands:
-  install:
-    parameters:
-      node-version:
-        description: Node.js version to install
-        type: string
-    steps:
-      - run: git config --global core.autocrlf input
-      - node/install:
-          node-version: << parameters.node-version >>
-      - run: nvm use << parameters.node-version >>
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
-            - v1-dependencies-{{ arch }}
-      - run: yarn install --frozen-lockfile
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
-  test:
-    steps:
-      - run: ./test/ci/generate-identity.sh
-      - run: yarn build && yarn test
-
-jobs:
-  test-mac:
-    macos:
-      xcode: "14.0.0"
-    resource_class: macos.x86.medium.gen2
-    parameters:
-      node-version:
-        description: Node.js version to install
-        type: string
-    steps:
-      - install:
-          node-version: << parameters.node-version >>
-      - test
+  node: electronjs/node@1.0.0
 
 workflows:
   test_and_release:
     # Run the test jobs first, then the release only when all the test jobs are successful
     jobs:
-      - test-mac:
+      - node/test:
+          executor: node/macos
+          name: test-<< matrix.executor >>-<< matrix.node-version >>
+          pre-steps:
+            - run: git config --global core.autocrlf input
+          test-steps:
+            - run: ./test/ci/generate-identity.sh
+            - run: yarn build && yarn test
           matrix:
+            alias: test-mac
             parameters:
               node-version:
-                - 20.3.1
-                - 18.16.1
+                - 20.5.0
+                - 18.17.0
                 - 16.20.1
                 - 14.21.3
       - cfa/release:
           requires:
-            - test-mac-20.3.1
-            - test-mac-18.16.1
-            - test-mac-16.20.1
-            - test-mac-14.21.3
+            - test-mac
           filters:
             branches:
               only:

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,0 +1,26 @@
+name: "Check Semantic Commit"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  main:
+    permissions:
+      pull-requests: read  # for amannn/action-semantic-pull-request to analyze PRs
+      statuses: write  # for amannn/action-semantic-pull-request to mark status of analyzed PR
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: semantic-pull-request
+        uses: amannn/action-semantic-pull-request@c3cd5d1ea3580753008872425915e343e351ab54 # v5.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          validateSingleCommit: false


### PR DESCRIPTION
* Uses `continuousauth/npm` orb for CFA releases
* Uses `electronjs/node` orb to simplify config
* Adds Node.js v20 to the test matrix
* Bumps Xcode version to one not deprecated by CircleCI
* Enforces semantic commit messages so CFA releases work as expected