### PR TITLE
fix: only apply `preAutoEntitlements` to top-level app bundle

### DIFF
--- a/src/sign.ts
+++ b/src/sign.ts
@@ -208,27 +208,31 @@ async function signApplication (opts: ValidatedSignOptions, identity: Identity) 
       defaultOptionsForFile(filePath, opts.platform)
     );
 
-    if (opts.preAutoEntitlements === false) {
-      debugWarn('Pre-sign operation disabled for entitlements automation.');
-    } else {
-      debugLog(
-        'Pre-sign operation enabled for entitlements automation with versions >= `1.1.1`:',
-        '\n',
-        '* Disable by setting `pre-auto-entitlements` to `false`.'
-      );
-      if (!opts.version || compareVersion(opts.version, '1.1.1') >= 0) {
-        // Enable Mac App Store sandboxing without using temporary-exception, introduced in Electron v1.1.1. Relates to electron#5601
-        const newEntitlements = await preAutoEntitlements(opts, perFileOptions, {
-          identity,
-          provisioningProfile: opts.provisioningProfile
-            ? await getProvisioningProfile(opts.provisioningProfile, opts.keychain)
-            : undefined
-        });
+    // preAutoEntitlements should only be applied to the top level app bundle.
+    // Applying it other files will cause the app to crash and be rejected by Apple.
+    if (!filePath.includes('.app/')) {
+      if (opts.preAutoEntitlements === false) {
+        debugWarn('Pre-sign operation disabled for entitlements automation.');
+      } else {
+        debugLog(
+          'Pre-sign operation enabled for entitlements automation with versions >= `1.1.1`:',
+          '\n',
+          '* Disable by setting `pre-auto-entitlements` to `false`.'
+        );
+        if (!opts.version || compareVersion(opts.version, '1.1.1') >= 0) {
+          // Enable Mac App Store sandboxing without using temporary-exception, introduced in Electron v1.1.1. Relates to electron#5601
+          const newEntitlements = await preAutoEntitlements(opts, perFileOptions, {
+            identity,
+            provisioningProfile: opts.provisioningProfile
+              ? await getProvisioningProfile(opts.provisioningProfile, opts.keychain)
+              : undefined
+          });
 
-        // preAutoEntitlements may provide us new entitlements, if so we update our options
-        // and ensure that entitlements-loginhelper has a correct default value
-        if (newEntitlements) {
-          perFileOptions.entitlements = newEntitlements;
+          // preAutoEntitlements may provide us new entitlements, if so we update our options
+          // and ensure that entitlements-loginhelper has a correct default value
+          if (newEntitlements) {
+            perFileOptions.entitlements = newEntitlements;
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes https://github.com/electron/osx-sign/issues/291
Fixes https://github.com/electron-userland/electron-builder/issues/7653

I've tested this in production and managed to publish my app to Mac App Store with the changes.

CC: @MarshallOfSound @mmaietta