### PR TITLE
chore: clear version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electron/osx-sign",
-  "version": "1.0.4",
+  "version": "0.0.0-development",
   "description": "Codesign Electron macOS apps",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
This package is released via CFA, and our convention is to set the version in `package.json` to `0.0.0-development`, otherwise it won't match the latest version (as is currently the case).