### PR TITLE
feat: add Use deep flag 😋 #240

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ Build version of Electron.
 Values may be like: `1.1.1`, `1.2.0`.
 Default to latest Electron version.
 
+`useDeepFlag` - *Boolean*
+
+Flag to `codesign --deep` All signing options will be applied, in turn, to all nested content. Warn: **(DEPRECATED for signing as of macOS 13.0) When signing a bundle, specifies that nested code content such as helpers, frameworks, and plug-ins, should be recursively signed in turn.** to see more content, please execute `man codesign` in the terminal.
+Default to `false`.
+
 It is recommended to utilize this option for best support of specific Electron versions. This may trigger pre/post operations for signing: For example, automation of setting `com.apple.security.application-groups` in entitlements file and of updating `Info.plist` with `ElectronTeamID` is enabled for all versions starting from `1.1.1`; set `preAutoEntitlements` option to `false` to disable this feature.
 
 #### From the Command Line

--- a/src/sign.ts
+++ b/src/sign.ts
@@ -185,6 +185,9 @@ async function signApplication (opts: ValidatedSignOptions, identity: Identity) 
   if (opts.keychain) {
     args.push('--keychain', opts.keychain);
   }
+  if (opts.useDeepFlag) {
+    args.push('--deep');
+  }
 
   /**
    * Sort the child paths by how deep they are in the file tree.  Some arcane apple

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ type OnlySignOptions = {
   strictVerify?: boolean;
   type?: SigningDistributionType;
   version?: string;
+  useDeepFlag?: boolean;
 };
 
 type OnlyValidatedSignOptions = {


### PR DESCRIPTION
This is a lightweight solution for https://github.com/electron/osx-sign/issues/240 issue. By adding the optional parameter `useDeepFlag` to `OnlySignOptions` to meet the needs of some people to add the `codesign --deep` identification, and configure the default value to `false` and explain the possible impact of this parameter in README. I think this should be an acceptable to most people. If you have any questions, please reply. I look forward to promoting this problem ⭐️.

Related links:
https://github.com/electron/osx-sign/pull/267
https://github.com/electron/osx-sign/pull/231
https://github.com/electron/osx-sign/issues/229

Many predecessors have encountered this problem and tried to discuss and solve it clearly. Thank them for their work 👏.

fixed https://github.com/electron/osx-sign/issues/240

cc @sethlu @MarshallOfSound 