### PR TITLE
feat: Exporting walkAsync

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { sign, signApp } from './sign';
 import { flat, buildPkg } from './flat';
+import { walkAsync } from './util';
 
 // TODO: Remove and leave only proper named exports, but for non-breaking change reasons
 // we need to keep this weirdness for now
@@ -10,6 +11,7 @@ module.exports.signApp = signApp;
 module.exports.flat = flat;
 module.exports.flatAsync = buildPkg;
 module.exports.buildPkg = buildPkg;
+module.exports.walkAsync = walkAsync;
 
-export { sign, flat, signApp as signAsync, signApp, buildPkg as flatAsync, buildPkg };
+export { sign, flat, signApp as signAsync, signApp, buildPkg as flatAsync, buildPkg, walkAsync };
 export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,8 @@ export type PerFileSignOptions = {
    */
   hardenedRuntime?: boolean;
   /**
-   * The designated requirements to embed when signing this file. Expects a path to a text file.
+   * The designated requirements to embed when signing this file. Expects a path to a text file,
+   * or a string beginning with "=" specifying requirements in plain text
    */
   requirements?: string;
   /**


### PR DESCRIPTION
This change exports the `walkAsync` function so that implementers can reliably generate an identical file list for purposes other than signing such as removing or inspecting individual file signatures. Also corrects type definition comments around requirements.