### PR TITLE
feat: add support for and document --deep for subresources

### DIFF
--- a/src/sign.ts
+++ b/src/sign.ts
@@ -126,7 +126,8 @@ function defaultOptionsForFile (filePath: string, platform: ElectronMacPlatform)
     hardenedRuntime: true,
     requirements: undefined as string | undefined,
     signatureFlags: undefined as string | string[] | undefined,
-    timestamp: undefined as string | undefined
+    timestamp: undefined as string | undefined,
+    additionalArguments: [] as string[] | undefined
   };
 }
 
@@ -157,6 +158,7 @@ async function mergeOptionsForFile (
       mergedPerFileOptions.signatureFlags = opts.signatureFlags;
     }
     if (opts.timestamp !== undefined) mergedPerFileOptions.timestamp = opts.timestamp;
+    if (opts.additionalArguments !== undefined) mergedPerFileOptions.additionalArguments = opts.additionalArguments;
   }
   return mergedPerFileOptions;
 }
@@ -284,6 +286,10 @@ async function signApplication (opts: ValidatedSignOptions, identity: Identity) 
 
     if (optionsArguments.length) {
       perFileArgs.push('--options', [...new Set(optionsArguments)].join(','));
+    }
+
+    if (perFileOptions.additionalArguments) {
+      perFileArgs.push(...perFileOptions.additionalArguments);
     }
 
     await execFileAsync(

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,13 @@ export type PerFileSignOptions = {
    * timestamp server.
    */
   timestamp?: string;
+  /**
+   * Additional raw arguments to pass to the "codesign" command.
+   *
+   * These can be things like "--deep" for instance when code signing specific resources that may
+   * require such arguments.
+   */
+  additionalArguments?: string[];
 }
 
 type OnlySignOptions = {


### PR DESCRIPTION
Adds docs, example and impl for using `--deep` in the "right" way.

Fixes #240