### PR TITLE
docs: update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Codesign Electron macOS apps
 
 ## Installation
 
+`@electron/osx-sign` is integrated into other Electron packaging tools, and can be configured accordingly:
+* [Electron Packager](https://electron.github.io/packager/main/types/OsxSignOptions.html)
+* [Electron Forge](https://www.electronforge.io/guides/code-signing/code-signing-macos)
+
+You can also install `@electron/osx-sign` separately if your packaging pipeline does not involve those tools:
+
 ```sh
 npm install --save-dev @electron/osx-sign
 ```

--- a/README.md
+++ b/README.md
@@ -13,20 +13,8 @@ Codesign Electron macOS apps
 ## Installation
 
 ```sh
-# For use in npm scripts
-npm install --save @electron/osx-sign
-# yarn
-yarn add @electron/osx-sign
+npm install --save-dev @electron/osx-sign
 ```
-
-```sh
-# For use from CLI
-npm install -g @electron/osx-sign
-# Yarn
-yarn global add @electron/osx-sign
-```
-
-*Note: `@electron/osx-sign` is a dependency of [`@electron/packager`](https://github.com/electron/packager) as of 6.0.0 for signing apps on macOS. However, feel free to install this package globally for more customization beyond specifying identity and entitlements.*
 
 ## Usage
 


### PR DESCRIPTION
* Recommend installation as a dev dependency
* Remove `yarn` instructions
* Remove global install recommendations