### PR TITLE
fix: fast memory/open file handle bail outs

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -183,6 +183,5 @@ export async function walkAsync (dirPath: string): Promise<string[]> {
     return binaryFiles;
   }
 
-  const allPaths = await _walkAsync(dirPath);
-  return compactFlattenedList(allPaths);
+  return await _walkAsync(dirPath);
 }


### PR DESCRIPTION
Please be kind :) 

i only hacked it together, since i do not find any tests for the util methods.
it is just an idea.

1. collecting everything for each "step" for each folder
2. remove tmp files with Promise.all - hopefully there are not that much
3. binary file check in chunks - so if there only a few files it runs in parallel, else batched
4. in the last step loop over all subfolders one by one and do step 1-4

