### PR TITLE
fix(flat): don't use `pkgbuild` for MAS distributions

### DIFF
--- a/src/flat.ts
+++ b/src/flat.ts
@@ -49,27 +49,44 @@ async function validateFlatOpts (opts: FlatOptions): Promise<ValidatedFlatOption
 
 /**
  * This function returns a promise flattening the application.
- * @function
- * @param {Object} opts - Options.
- * @returns {Promise} Promise.
+ * @param opts - Options for building the .pkg archive
  */
 async function buildApplicationPkg (opts: ValidatedFlatOptions, identity: Identity) {
-  const componentPkgPath = path.join(path.dirname(opts.app), path.basename(opts.app, '.app') + '-component.pkg');
-  const pkgbuildArgs = ['--install-location', opts.install, '--component', opts.app, componentPkgPath];
-  if (opts.scripts) {
-    pkgbuildArgs.unshift('--scripts', opts.scripts);
-  }
-  debugLog('Building component package... ' + opts.app);
-  await execFileAsync('pkgbuild', pkgbuildArgs);
+  if (opts.platform === 'mas') {
+    const args = ['--component', opts.app, opts.install, '--sign', identity.name, opts.pkg];
+    if (opts.keychain) {
+      args.unshift('--keychain', opts.keychain);
+    }
 
-  const args = ['--package', componentPkgPath, opts.install, '--sign', identity.name, opts.pkg];
-  if (opts.keychain) {
-    args.unshift('--keychain', opts.keychain);
-  }
+    debugLog('Flattening Mac App Store package... ' + opts.app);
+    await execFileAsync('productbuild', args);
+  } else {
+    const componentPkgPath = path.join(
+      path.dirname(opts.app),
+      path.basename(opts.app, '.app') + '-component.pkg'
+    );
+    const pkgbuildArgs = [
+      '--install-location',
+      opts.install,
+      '--component',
+      opts.app,
+      componentPkgPath
+    ];
+    if (opts.scripts) {
+      pkgbuildArgs.unshift('--scripts', opts.scripts);
+    }
+    debugLog('Building component package... ' + opts.app);
+    await execFileAsync('pkgbuild', pkgbuildArgs);
 
-  debugLog('Flattening... ' + opts.app);
-  await execFileAsync('productbuild', args);
-  await execFileAsync('rm', [componentPkgPath]);
+    const args = ['--package', componentPkgPath, opts.install, '--sign', identity.name, opts.pkg];
+    if (opts.keychain) {
+      args.unshift('--keychain', opts.keychain);
+    }
+
+    debugLog('Flattening OS X Installer package... ' + opts.app);
+    await execFileAsync('productbuild', args);
+    await execFileAsync('rm', [componentPkgPath]);
+  }
 }
 
 /**
@@ -97,15 +114,15 @@ export async function buildPkg (_opts: FlatOptions) {
       debugLog(
         'Finding `3rd Party Mac Developer Installer` certificate for flattening app distribution in the Mac App Store...'
       );
-      identities = await findIdentities(
-        validatedOptions.keychain || null,
-        '3rd Party Mac Developer Installer:'
-      );
+      identities = await findIdentities(validatedOptions.keychain || null, '3rd Party Mac Developer Installer:');
     } else {
       debugLog(
         'Finding `Developer ID Application` certificate for distribution outside the Mac App Store...'
       );
-      identities = await findIdentities(validatedOptions.keychain || null, 'Developer ID Installer:');
+      identities = await findIdentities(
+        validatedOptions.keychain || null,
+        'Developer ID Installer:'
+      );
     }
   }
 

--- a/src/flat.ts
+++ b/src/flat.ts
@@ -39,6 +39,10 @@ async function validateFlatOpts (opts: FlatOptions): Promise<ValidatedFlatOption
     install = '/Applications';
   }
 
+  if (typeof opts.scripts === 'string' && opts.platform === 'mas') {
+    debugWarn('Mac App Store packages cannot have `scripts`, ignoring option.');
+  }
+
   return {
     ...opts,
     pkg,
@@ -114,7 +118,10 @@ export async function buildPkg (_opts: FlatOptions) {
       debugLog(
         'Finding `3rd Party Mac Developer Installer` certificate for flattening app distribution in the Mac App Store...'
       );
-      identities = await findIdentities(validatedOptions.keychain || null, '3rd Party Mac Developer Installer:');
+      identities = await findIdentities(
+        validatedOptions.keychain || null,
+        '3rd Party Mac Developer Installer:'
+      );
     } else {
       debugLog(
         'Finding `Developer ID Application` certificate for distribution outside the Mac App Store...'

--- a/src/types.ts
+++ b/src/types.ts
@@ -220,6 +220,8 @@ type OnlyFlatOptions = {
    * Path to a directory containing `preinstall.sh` or `postinstall.sh` scripts.
    * These must be executable and will run on pre/postinstall depending on the file
    * name.
+   *
+   * This option is only valid if {@link FlatOptions.platform} is set to `darwin`.
    */
   scripts?: string;
 };


### PR DESCRIPTION
Fixes #327
Fixes #328 
Fixes https://github.com/electron/forge/issues/3782

## Context

The `flat` function of `@electron/osx-sign` is used to generate `.pkg` archives for macOS. These archives can be installed on users' machines in two ways:

* via OS X Installer (i.e. clicking the `.pkg` archive on your file system)
* via the Mac App Store (MAS)

There are two underlying macOS tools that can be used to generate these archives: [`productbuild`](https://www.unix.com/man-page/osx/1/productbuild/) and [`pkgbuild`](https://www.unix.com/man-page/osx/1/pkgbuild/).

## Regression

#282 fixed the problem of not being to use pre/postinstall scripts in `.pkg` installers by adding an additional `pkgbuild` incantation to add those scripts and inserting that build into the final `productbuild` bundle.

It turns out that this created invalid output for MAS build targets. This is because `pkgbuild` isn't supposed to be used for Mac App Store builds according to the manpage:

> A "component package" contains payload to be installed by the OS X Installer. Although a component package can be installed on its own, it is typically incorporated into a product archive, along with a "distribution" and localized resources, using [productbuild(1)](https://www.unix.com/man-page/osx/1/productbuild/).

> To create a product archive for submission to the Mac App Store, do not use pkgbuild.  Instead, use [productbuild(1)](https://www.unix.com/man-page/osx/1/productbuild/) directly.To create a product archive for submission to the Mac App Store, do not use pkgbuild.  Instead, use [productbuild(1)](https://www.unix.com/man-page/osx/1/productbuild/) directly.

## Solution

My proposed solution is to branch between the previous and current implementation based on the build target (MAS vs. OS X Installer). This will fix the regression for MAS builds while still preserving the ability to add pre/postinstall scripts for OS X Installer archives.

It turns out that pre/postinstall scripts are a non-feature for MAS builds anyways according to both Apple Developer Technical Support [1](https://developer.apple.com/forums/thread/661596?answerId=635723022#635723022) and the `productbuild` manpage [2](https://www.unix.com/man-page/osx/1/productbuild/#:~:text=This%20is%20valid%0A%09%09%20only%20for%20product%20archives%20targeted%20to%20the%20OS%20X%20Installer%20application.).