### PR TITLE
perf: parallelize signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "fs-extra": "^10.0.0",
     "isbinaryfile": "^4.0.8",
     "minimist": "^1.2.6",
+    "p-limit": "^6.2.0",
     "plist": "^3.0.5"
   },
   "devDependencies": {

--- a/src/util.ts
+++ b/src/util.ts
@@ -142,7 +142,7 @@ export async function walkAsync (dirPath: string): Promise<string[]> {
       children.map(async (child) => {
         const filePath = path.resolve(dirPath, child);
 
-        const stat = await fs.stat(filePath);
+        const stat = await fs.lstat(filePath);
         if (stat.isFile()) {
           switch (path.extname(filePath)) {
             case '.cstemp': // Temporary file generated from past codesign


### PR DESCRIPTION
When you're signing an application that includes a lot of native code, e.g. dylibs and executables, the time it takes to sign it all can balloon up to hours-- this is the case for myself on a project that includes GStreamer (which is massive).

This commit does signing in parallel. It's slightly nuanced-- the Apple code signing tool can't operate on a higher directory level directory while signing is going on below, so we need to handle it at the leaf nodes first and then continue upwards. It's really weird and unintuitive, but oh well; this PR handles those cases properly.

For me this knocks signing time down from hours to about a minute.

Additionally, this PR fixes a bug in the existing code, where `stat` is incorrectly used instead of `lstat`, meaning that the later check in the code for `.isSymbolicLink()` would never return true.