### PR TITLE
fix: strictVerify not working with true value

### DIFF
--- a/src/sign.ts
+++ b/src/sign.ts
@@ -78,8 +78,8 @@ async function verifySignApplication (opts: ValidatedSignOptions) {
       opts.strictVerify !== false && compareVersion(osRelease, '15.0.0') >= 0 // Strict flag since darwin 15.0.0 --> OS X 10.11.0 El Capitan
         ? [
             '--strict' +
-              (opts.strictVerify
-                ? '=' + opts.strictVerify // Array should be converted to a comma separated string
+              (opts.strictVerify !== true
+                ? '=' + opts.strictVerify
                 : '')
           ]
         : [],

--- a/src/sign.ts
+++ b/src/sign.ts
@@ -72,15 +72,14 @@ async function verifySignApplication (opts: ValidatedSignOptions) {
   // Verify with codesign
   debugLog('Verifying application bundle with codesign...');
 
+  const strictVerify = opts.strictVerify !== undefined ? opts.strictVerify : true;
   await execFileAsync(
     'codesign',
     ['--verify', '--deep'].concat(
-      opts.strictVerify !== false && compareVersion(osRelease, '15.0.0') >= 0 // Strict flag since darwin 15.0.0 --> OS X 10.11.0 El Capitan
+      strictVerify !== false && compareVersion(osRelease, '15.0.0') >= 0 // Strict flag since darwin 15.0.0 --> OS X 10.11.0 El Capitan
         ? [
             '--strict' +
-              (opts.strictVerify !== true
-                ? '=' + opts.strictVerify
-                : '')
+              (strictVerify !== true ? '=' + strictVerify : '')
           ]
         : [],
       ['--verbose=2', opts.app]

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,10 +174,11 @@ export type OnlySignOptions = {
   provisioningProfile?: string;
   /**
    * Flag to enable/disable the `--strict` flag when verifying the signed application bundle.
+   * Also supports string values to specify which strict restrictions to use, see codesign man page for supported values.
    *
    * @defaultValue `true`
    */
-  strictVerify?: boolean;
+  strictVerify?: boolean | string;
   /**
    * Type of certificate to use when signing a MAS app.
    * @defaultValue `"distribution"`


### PR DESCRIPTION
And extend it to support string-specified restrictions

Fixes https://github.com/electron/osx-sign/issues/344