### PR TITLE
feat(perf): add `batchCodesignCalls` option to allow signing multiple files at once

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,14 @@ export type PerFileSignOptions = {
  */
 export type OnlySignOptions = {
   /**
+   * Combine all files with identical CLI arguments in a single `codesign` call instead of running
+   * `codesign` once for each of those files. This minimizes the number of child processes that need
+   * to be spawned and reduces the time it takes to sign all files.
+   *
+   * @defaultValue `false`
+   */
+  batchCodesignCalls?: boolean;
+  /**
    * Array of paths to additional binaries that will be signed along with built-ins of Electron.
    *
    * @defaultValue `undefined`

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,7 @@ export type OnlySignOptions = {
    * to be spawned and reduces the time it takes to sign all files.
    *
    * @defaultValue `false`
+   * @experimental
    */
   batchCodesignCalls?: boolean;
   /**


### PR DESCRIPTION
This adds the `batchCodesignCalls` option to allow signing all files with identical options at a given filesystem depth in a single `codesign` call (as opposed to running `codesign` once for each file in a serial fashion), which minimizes the number of child processes that need to be spawned and reduces the time it takes to sign the app. That option defaults to **`false`**, so users need to explicitly opt into that behavior.

---

I was recently debugging a code-signing issue and noticed in the logs that we're signing one file at a time, which translates to a few hundreds of `childProcess.exec('codesign')` calls. `codesign` supports passing multiple files at once, so we can take advantage of that to keep the number of child processes we have to spawn (and the associated overhead) to a minimum.

At first, I tried to sign __all files__ with identical args with a single `codesign` call, but the tests for the `v7.0.0-beta.3-darwin-x64` and `v7.0.0-beta.3-mas-x64` artifacts were failing. I figured that was related to fact that that we're supposed to sign the bundle from the inside out as described [here](https://github.com/electron/osx-sign/blob/757fa60716efd7310006153c55172fdcec46452a/src/sign.ts#L191-L195), so I changed the logic to take into account the position of the files in the file tree, and now all files at the same depth that share the same arguments are signed at the same time.

I did some crude benchmarking on my machine with the Electron artifacts used in `@electron/osx-sign`'s test cases by `console.time`ing the total time spent and counting how many child processes we're spawning. Using the `main` branch, the heaviest artifact is `v6.0.3-darwin-x64`, which takes 55.737s to complete and calls `codesign` 227 times in total — with my branch, the same artifact is signed in 47.938s (~14% less time) while spawning only 13 child processes.

I didn't realize we had an [open PR](https://github.com/electron/osx-sign/pull/341) for improving code-signing performance until just before opening this one. @SuperDisk, I couldn't test your branch locally because of some build errors, but if my PR lands before yours let me know if it helps with your use case. My PR uses a different approach, so if it doesn't solve your problem completely it could potentially speed things up some more when combined with your changes.

Closes https://github.com/electron/osx-sign/issues/305.