### PR TITLE
build: publish to correct directories again

### DIFF
--- a/src/flat.ts
+++ b/src/flat.ts
@@ -5,7 +5,9 @@ import { Identity, findIdentities } from './util-identities';
 
 import { FlatOptions, ValidatedFlatOptions } from './types';
 
-import { version as pkgVersion } from '../package.json';
+// This directory doesn't work in dev but in prod we publish to /dist/cjs/flat.js so package.json is 2 levels up
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const pkgVersion = require('../../package.json').version as string;
 
 /**
  * This function returns a promise validating all options passed in opts.

--- a/src/sign.ts
+++ b/src/sign.ts
@@ -23,7 +23,9 @@ import {
   ValidatedSignOptions,
 } from './types';
 
-import { version as pkgVersion } from '../package.json';
+// This directory doesn't work in dev but in prod we publish to /dist/cjs/sign.js so package.json is 2 levels up
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const pkgVersion = require('../../package.json').version as string;
 
 const osRelease = os.release();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "moduleResolution": "node",
     "declaration": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Fast follow-up to https://github.com/electron/osx-sign/pull/348

In the previous PR, I used `resolveJsonModule` to avoid a `@typescript-eslint/no-var-requires` error, but this led to the `dist` structure to change, which broke the tests.