### PR TITLE
refactor: replace `compare-version` with `semver`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,13 @@
   "description": "Codesign Electron macOS apps",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "files": ["dist", "entitlements", "README.md", "LICENSE", "bin"],
+  "files": [
+    "dist",
+    "entitlements",
+    "README.md",
+    "LICENSE",
+    "bin"
+  ],
   "bin": {
     "electron-osx-flat": "bin/electron-osx-flat.js",
     "electron-osx-sign": "bin/electron-osx-sign.js"
@@ -23,20 +29,20 @@
   },
   "homepage": "https://github.com/electron/osx-sign",
   "dependencies": {
-    "compare-version": "^0.1.2",
     "debug": "^4.3.4",
     "fs-extra": "^10.0.0",
     "isbinaryfile": "^4.0.8",
     "minimist": "^1.2.6",
-    "plist": "^3.0.5"
+    "plist": "^3.0.5",
+    "semver": "^7.7.1"
   },
   "devDependencies": {
     "@electron/get": "^2.0.2",
-    "@types/compare-version": "^0.1.31",
     "@types/debug": "^4.1.7",
     "@types/fs-extra": "^9.0.13",
     "@types/node": "^16.11.6",
     "@types/plist": "^3.0.2",
+    "@types/semver": "^7.5.8",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
     "eslint": "^8.29.0",
@@ -69,6 +75,9 @@
   },
   "lint-staged": {
     "*.{json}": "prettier --write",
-    "*.{js,ts}": ["prettier --write", "eslint --fix"]
+    "*.{js,ts}": [
+      "prettier --write",
+      "eslint --fix"
+    ]
   }
 }

--- a/src/sign.ts
+++ b/src/sign.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import * as plist from 'plist';
-import compareVersion from 'compare-version';
+import * as semver from 'semver';
 
 import {
   debugLog,
@@ -83,7 +83,7 @@ async function verifySignApplication(opts: ValidatedSignOptions) {
   await execFileAsync(
     'codesign',
     ['--verify', '--deep'].concat(
-      strictVerify !== false && compareVersion(osRelease, '15.0.0') >= 0 // Strict flag since darwin 15.0.0 --> OS X 10.11.0 El Capitan
+      strictVerify !== false && semver.gte(osRelease, '15.0.0') // Strict flag since darwin 15.0.0 --> OS X 10.11.0 El Capitan
         ? ['--strict' + (strictVerify !== true ? '=' + strictVerify : '')]
         : [],
       ['--verbose=2', opts.app],
@@ -228,7 +228,7 @@ async function signApplication(opts: ValidatedSignOptions, identity: Identity) {
           '\n',
           '* Disable by setting `pre-auto-entitlements` to `false`.',
         );
-        if (!opts.version || compareVersion(opts.version, '1.1.1') >= 0) {
+        if (!opts.version || semver.gte(opts.version, '1.1.1')) {
           // Enable Mac App Store sandboxing without using temporary-exception, introduced in Electron v1.1.1. Relates to electron#5601
           const newEntitlements = await preAutoEntitlements(opts, perFileOptions, {
             identity,
@@ -278,7 +278,7 @@ async function signApplication(opts: ValidatedSignOptions, identity: Identity) {
 
     if (perFileOptions.hardenedRuntime || optionsArguments.includes('runtime')) {
       // Hardened runtime since darwin 17.7.0 --> macOS 10.13.6
-      if (compareVersion(osRelease, '17.7.0') >= 0) {
+      if (semver.gte(osRelease, '17.7.0')) {
         optionsArguments.push('runtime');
       } else {
         // Remove runtime if passed in with --signature-flags

--- a/test/util.js
+++ b/test/util.js
@@ -5,7 +5,7 @@ const { downloadArtifact } = require('@electron/get');
 const mkdirp = require('mkdirp');
 const rimraf = require('rimraf');
 const series = require('run-series');
-const compareVersion = require('compare-version');
+const semver = require('semver');
 const extract = require('extract-zip');
 
 const config = require('./config');
@@ -23,50 +23,54 @@ versions.forEach(function (version) {
   archs.forEach(function (arch) {
     platforms.forEach(function (platform) {
       // Only versions later than 0.34.0 offer mas builds
-      if (platform !== 'mas' || compareVersion(version, '0.34.0') >= 0) {
+      if (platform !== 'mas' || semver.gte(version, '0.34.0')) {
         releases.push({
           arch,
           platform,
-          version
+          version,
         });
       }
     });
   });
 });
 
-exports.generateReleaseName = function getExtractName (release) {
+exports.generateReleaseName = function getExtractName(release) {
   return 'v' + release.version + '-' + release.platform + '-' + release.arch;
 };
 
-exports.generateAppPath = function getExtractName (release) {
+exports.generateAppPath = function getExtractName(release) {
   return path.join(exports.generateReleaseName(release), 'Electron.app');
 };
 
-exports.downloadElectrons = function downloadElectrons (callback) {
+exports.downloadElectrons = function downloadElectrons(callback) {
   console.log('Downloading...');
   series(
     releases.map(function (release) {
       return function (cb) {
         downloadArtifact({ ...release, artifactName: 'electron' })
-          .then((zipPath) => extract(zipPath, { dir: path.join(WORK_CWD, exports.generateReleaseName(release)) }))
+          .then((zipPath) =>
+            extract(zipPath, { dir: path.join(WORK_CWD, exports.generateReleaseName(release)) }),
+          )
           .then(() => cb())
           .catch(cb);
       };
     }),
-    callback
+    callback,
   );
 };
 
-exports.setup = function setup () {
+exports.setup = function setup() {
   test('setup', function (t) {
-    mkdirp(WORK_CWD).then(() => {
-      process.chdir(WORK_CWD);
-      t.end();
-    }).catch((err) => t.end(err));
+    mkdirp(WORK_CWD)
+      .then(() => {
+        process.chdir(WORK_CWD);
+        t.end();
+      })
+      .catch((err) => t.end(err));
   });
 };
 
-exports.teardown = function teardown () {
+exports.teardown = function teardown() {
   test('teardown', function (t) {
     process.chdir(ORIGINAL_CWD);
     rimraf(WORK_CWD, function (err) {
@@ -75,17 +79,17 @@ exports.teardown = function teardown () {
   });
 };
 
-exports.forEachRelease = function forEachRelease (cb) {
+exports.forEachRelease = function forEachRelease(cb) {
   releases.forEach(cb);
 };
 
-exports.testAllReleases = function testAllReleases (name, createTest /*, ...createTestArgs */) {
+exports.testAllReleases = function testAllReleases(name, createTest /*, ...createTestArgs */) {
   const args = slice.call(arguments, 2);
   exports.setup();
   exports.forEachRelease(function (release) {
     test(
       name + ':' + exports.generateReleaseName(release),
-      createTest.apply(null, [release].concat(args))
+      createTest.apply(null, [release].concat(args)),
     );
   });
   exports.teardown();

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,11 +94,6 @@
     "@types/node" "*"
     "@types/responselike" "^1.0.0"
 
-"@types/compare-version@^0.1.31":
-  version "0.1.31"
-  resolved "https://registry.yarnpkg.com/@types/compare-version/-/compare-version-0.1.31.tgz#80225ddf96787302efcf4ad459a6b2a564cd608e"
-  integrity sha512-Yi8dTcaY31y2fDdl68eobTKeihUv3USrnvvmlLWg8XLYCj9ToMEtn4KURPgtmBWP2/lIeoq8NLjOfXHGMtCZIQ==
-
 "@types/debug@^4.1.7":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
@@ -164,6 +159,11 @@
   version "7.3.13"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+
+"@types/semver@^7.5.8":
+  version "7.5.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
+  integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
 
 "@types/yauzl@^2.9.1":
   version "2.9.2"
@@ -421,11 +421,6 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
-compare-version@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080"
-  integrity sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA=
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1862,6 +1857,11 @@ semver@^7.3.2, semver@^7.3.7:
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.7.1:
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
+  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
 
 serialize-error@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
https://www.npmjs.com/package/compare-version is an 11-year-old package that runs SemVer-based comparison checks. The repo no longer exists anymore, so let's replace it with the popular `semver` package instead.

Note that there's one non-SemVer check that we use this compare utility on. It's on the `os.release()` corresponding to the Darwin version, which also uses the same `a.b.c` format the SemVer does.

I don't expect any incompatibility stemming from this change, but I'm happy to write our own version comparison util if that proves to be an incorrect assumption.