### PR TITLE
refactor: remove `graceful-fs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
   },
   "homepage": "https://github.com/electron/osx-sign",
   "dependencies": {
-    "@types/graceful-fs": "^4.1.9",
     "debug": "^4.3.4",
-    "graceful-fs": "^4.2.11",
     "isbinaryfile": "^4.0.8",
     "plist": "^3.0.5",
     "semver": "^7.7.1"

--- a/src/sign.ts
+++ b/src/sign.ts
@@ -1,8 +1,7 @@
+import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import util from 'node:util';
 
-import fs from 'graceful-fs';
 import plist from 'plist';
 import semver from 'semver';
 
@@ -152,7 +151,7 @@ async function mergeOptionsForFile(
         );
         const dir = await fs.promises.mkdtemp(path.resolve(os.tmpdir(), 'tmp-entitlements-'));
         const entitlementsPath = path.join(dir, 'entitlements.plist');
-        await util.promisify(fs.writeFile)(entitlementsPath, plist.build(entitlements), 'utf8');
+        await fs.promises.writeFile(entitlementsPath, plist.build(entitlements), 'utf8');
         opts.entitlements = entitlementsPath;
       }
       mergedPerFileOptions.entitlements = opts.entitlements;

--- a/src/util-entitlements.ts
+++ b/src/util-entitlements.ts
@@ -1,8 +1,7 @@
+import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import util from 'node:util';
 
-import fs from 'graceful-fs';
 import plist from 'plist';
 
 import type { PerFileSignOptions, ValidatedSignOptions } from './types.js';
@@ -41,10 +40,7 @@ export async function preAutoEntitlements(
   debugLog('Automating entitlement app group...', '\n', '> Info.plist:', appInfoPath, '\n');
   let entitlements: Record<string, any>;
   if (typeof perFileOpts.entitlements === 'string') {
-    const entitlementsContents = await util.promisify(fs.readFile)(
-      perFileOpts.entitlements,
-      'utf8',
-    );
+    const entitlementsContents = await fs.promises.readFile(perFileOpts.entitlements, 'utf8');
     entitlements = plist.parse(entitlementsContents) as Record<string, any>;
   } else {
     entitlements = perFileOpts.entitlements.reduce<Record<string, any>>(
@@ -60,7 +56,7 @@ export async function preAutoEntitlements(
     return;
   }
 
-  const appInfoContents = await util.promisify(fs.readFile)(appInfoPath, 'utf8');
+  const appInfoContents = await fs.promises.readFile(appInfoPath, 'utf8');
   const appInfo = plist.parse(appInfoContents) as Record<string, any>;
   // Use ElectronTeamID in Info.plist if already specified
   if (appInfo.ElectronTeamID) {
@@ -87,7 +83,7 @@ export async function preAutoEntitlements(
           appInfo.ElectronTeamID,
       );
     }
-    await util.promisify(fs.writeFile)(appInfoPath, plist.build(appInfo), 'utf8');
+    await fs.promises.writeFile(appInfoPath, plist.build(appInfo), 'utf8');
 
     debugLog('`Info.plist` updated:', '\n', '> Info.plist:', appInfoPath);
   }
@@ -141,7 +137,7 @@ export async function preAutoEntitlements(
   // Create temporary entitlements file
   const dir = await fs.promises.mkdtemp(path.resolve(os.tmpdir(), 'tmp-entitlements-'));
   const entitlementsPath = path.join(dir, 'entitlements.plist');
-  await util.promisify(fs.writeFile)(entitlementsPath, plist.build(entitlements), 'utf8');
+  await fs.promises.writeFile(entitlementsPath, plist.build(entitlements), 'utf8');
   debugLog('Entitlements file updated:', '\n', '> Entitlements:', entitlementsPath);
 
   preAuthMemo.set(memoKey, entitlementsPath);

--- a/src/util-provisioning-profiles.ts
+++ b/src/util-provisioning-profiles.ts
@@ -1,7 +1,6 @@
+import fs from 'node:fs';
 import path from 'node:path';
-import util from 'node:util';
 
-import fs from 'graceful-fs';
 import plist from 'plist';
 
 import type { ElectronMacPlatform, ValidatedSignOptions } from './types.js';
@@ -85,7 +84,7 @@ export async function getProvisioningProfile(filePath: string, keychain: string 
  */
 export async function findProvisioningProfiles(opts: ValidatedSignOptions) {
   const cwd = process.cwd();
-  const children = await util.promisify(fs.readdir)(cwd);
+  const children = await fs.promises.readdir(cwd);
   const foundProfiles = compactFlattenedList(
     await Promise.all(
       children.map(async (child) => {
@@ -137,7 +136,7 @@ export async function preEmbedProvisioningProfile(
       );
     } else {
       debugLog('Embedding provisioning profile...');
-      await util.promisify(fs.copyFile)(profile.filePath, embeddedFilePath);
+      await fs.promises.copyFile(profile.filePath, embeddedFilePath);
     }
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,8 +1,7 @@
 import child from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
-import util from 'node:util';
 
-import fs from 'graceful-fs';
 import { isBinaryFile } from 'isbinaryfile';
 
 import debug from 'debug';
@@ -139,7 +138,7 @@ export async function walk(dirPath: string): Promise<string[]> {
   debugLog('Walking... ' + dirPath);
 
   async function _walkAsync(dirPath: string): Promise<DeepList<string>> {
-    const children = await util.promisify(fs.readdir)(dirPath);
+    const children = await fs.promises.readdir(dirPath);
     return await Promise.all(
       children.map(async (child) => {
         const filePath = path.resolve(dirPath, child);

--- a/yarn.lock
+++ b/yarn.lock
@@ -386,13 +386,6 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
 
-"@types/graceful-fs@^4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.9.tgz#2a06bc0f68a20ab37b3e36aa238be6abdf49e8b4"
-  integrity sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/http-cache-semantics@^4.0.4":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#b979ebad3919799c979b17c72621c0bc0a31c6c4"


### PR DESCRIPTION
As per internal maintainer discussion, the value from `graceful-fs` comes from its handling of filesystem errors on Windows.

Since this package is strictly for macOS code-signing, let's drop it as a dep and use `node:fs` directly.