### PR TITLE
chore: convert JSDoc comments to TSDoc

### DIFF
--- a/src/flat.ts
+++ b/src/flat.ts
@@ -13,9 +13,8 @@ import type { FlatOptions, ValidatedFlatOptions } from './types.js';
 
 /**
  * This function returns a promise validating all options passed in opts.
- * @function
- * @param {Object} opts - Options.
- * @returns {Promise} Promise.
+ *
+ * @param opts - Options.
  */
 async function validateFlatOpts(opts: FlatOptions): Promise<ValidatedFlatOptions> {
   await validateOptsApp(opts);

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,7 +128,7 @@ export type OnlySignOptions = {
    * object this function returns can include any of the following optional keys. Any properties that are returned **override** the default
    * values that `@electron/osx-sign` generates. Any properties not returned use the default value.
    *
-   * @param filePath Path to file
+   * @param filePath - Path to file
    * @returns Override signing options
    */
   optionsForFile?: (filePath: string) => PerFileSignOptions;

--- a/src/util-provisioning-profiles.ts
+++ b/src/util-provisioning-profiles.ts
@@ -39,10 +39,9 @@ export class ProvisioningProfile {
 
 /**
  * Returns a promise resolving to a ProvisioningProfile instance based on file.
- * @function
- * @param {string} filePath - Path to provisioning profile.
- * @param {string} keychain - Keychain to use when unlocking provisioning profile.
- * @returns {Promise} Promise.
+ *
+ * @param filePath - Path to provisioning profile.
+ * @param keychain - Keychain to use when unlocking provisioning profile.
  */
 export async function getProvisioningProfile(filePath: string, keychain: string | null = null) {
   const securityArgs = [

--- a/src/util.ts
+++ b/src/util.ts
@@ -129,9 +129,9 @@ export async function validateOptsPlatform(opts: BaseSignOptions): Promise<Elect
 
 /**
  * This function returns a promise resolving all child paths within the directory specified.
- * @function
- * @param {string} dirPath - Path to directory.
- * @returns {Promise} Promise resolving child paths needing signing in order.
+ *
+ * @param dirPath - Path to directory.
+ * @returns Promise resolving child paths needing signing in order.
  * @internal
  */
 export async function walk(dirPath: string): Promise<string[]> {


### PR DESCRIPTION
Most of the "conversion" here is simply deleting `@param` and `@returns` which are only types, since they're redundant to the TS types, sometimes wrong, and TSDoc doesn't include types for obvious reasons.