### PR TITLE
docs: Improve explanation of certificate pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ installed in your keychain. We recommend installing them in your system default 
 that `@electron/osx-sign` can detect them automatically.
 
 **Note:** Apple developer certificates tend to come in related pairs. It’s simplest to install
-both of them. However, if you only want to distribute outside the Mac App Store, there is no
-need to have the 3rd Party Mac Developer ones installed, and vice versa.
+both of them for future use. However, if you only want to distribute outside the Mac App Store,
+there is no need to have the 3rd Party Mac Developer ones installed, and vice versa.
 
 ### API
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,8 @@ After you create the necessary certifications, download them and open each so th
 installed in your keychain. We recommend installing them in your system default keychain so
 that `@electron/osx-sign` can detect them automatically.
 
-**Note:** They appear to come in pairs. It is preferred to have every one of them installed so not to 
-are about which is not yet installed for future works. However, if you may only want to distribute
-outside the Mac App Store, there is no need to have the 3rd Party Mac Developer ones installed and vice versa.
+**Note:** Apple developer certificates tend to come in related pairs. It’s simplest to install both of them. However, if you only want to distribute
+outside the Mac App Store, there is no need to have the 3rd Party Mac Developer ones installed, and vice versa.
 
 ### API
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ After you create the necessary certifications, download them and open each so th
 installed in your keychain. We recommend installing them in your system default keychain so
 that `@electron/osx-sign` can detect them automatically.
 
-**Note:** Apple developer certificates tend to come in related pairs. It’s simplest to install both of them. However, if you only want to distribute
-outside the Mac App Store, there is no need to have the 3rd Party Mac Developer ones installed, and vice versa.
+**Note:** Apple developer certificates tend to come in related pairs. It’s simplest to install
+both of them. However, if you only want to distribute outside the Mac App Store, there is no
+need to have the 3rd Party Mac Developer ones installed, and vice versa.
 
 ### API
 


### PR DESCRIPTION
The previous phrase "so not to are about which is not yet installed for future works" had some typos which made it difficult to read. This should be clearer.