### PR TITLE
fix: Use lstat instead of stat

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -143,7 +143,7 @@ export async function walk(dirPath: string): Promise<string[]> {
       children.map(async (child) => {
         const filePath = path.resolve(dirPath, child);
 
-        const stat = await fs.promises.stat(filePath);
+        const stat = await fs.promises.lstat(filePath);
         if (stat.isFile()) {
           switch (path.extname(filePath)) {
             case '.cstemp': // Temporary file generated from past codesign


### PR DESCRIPTION
This PR changes a use of `stat` in `walkAsync` to be `lstat` instead, which works the same except it returns information about symbolic links instead of following them. The original code actually checks `.isSymbolicLink()` a few lines below, which will never return true for `stat`.

This fixes a bug when signing frameworks, and is one of the patches in our `osx-sign` [fork](https://github.com/recallai/osx-sign) that our customers are using.

@erickzhao I just saw you LGTM'd erikian's performance improvement PR which was the one other thing in our fork, so once this is in I'll be happy to retire that 😄 