### PR TITLE
feat: add a pure-JavaScript flat package implementation

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: verify
+description: Build-and-drive recipe for verifying @electron/osx-sign changes end-to-end on macOS.
+---
+
+# Verifying @electron/osx-sign
+
+## Build
+
+```bash
+yarn build        # tsc → dist/ (the bin/ CLIs import from dist/)
+```
+
+## Surfaces
+
+- **CLI**: `node bin/electron-osx-flat.mjs <App.app> [--implementation=js] [--platform=darwin|mas] [--pkg=out.pkg]`
+  and `node bin/electron-osx-sign.mjs <App.app> [...]`. Both read from `dist/`, so build first.
+- **Library**: `flat()` / `sign()` from the package root export.
+
+## Getting a real app to package
+
+Download a real Electron.app (cached by @electron/get after first run):
+
+```bash
+node -e '
+const { downloadArtifact } = require("@electron/get");
+const { extract } = require("@electron-internal/extract-zip");
+downloadArtifact({ version: "35.0.3", platform: "darwin", arch: process.arch, artifactName: "electron" })
+  .then((zip) => extract(zip, { dir: process.argv[1] }))' /tmp/electron-dist
+```
+
+## Observing the output pkg
+
+- `pkgutil --expand-full out.pkg expanded-dir` then `diff -r App.app expanded-dir/*.pkg/Payload/App.app`
+  is the strongest check — it runs Apple's real extraction path. "Directory loop detected"
+  warnings from diff on framework symlinks are benign when they appear on both sides.
+- `lsbom <extracted Bom>` validates the Bill-of-Materials.
+- `installer -pkg out.pkg -volinfo` exercises Installer's package parsing without installing.
+- Actually installing requires sudo — don't.
+
+## Gotchas
+
+- **Native Apple tools (pkgbuild/productbuild/pkgutil/installer/lsbom) hang or crash under
+  the Bash-tool seatbelt sandbox.** Run them with the sandbox disabled.
+- **Files created by this session's processes get `com.apple.provenance` xattrs**, which
+  make native pkgbuild emit AppleDouble (`._*`) entries. When byte-comparing against
+  native output, filter `._*` entries and renumber cpio inodes (see
+  `spec/pkg-utils/helpers.ts` `normalizeCpio`).
+- Signing verification needs the self-signed identity from `spec/ci/generate-identity.sh`;
+  without it, `sign.spec.ts` fails with "No identity found" (pre-existing on dev machines).
+- `yarn bench` benchmarks the JS packager against the native tools;
+  `OSX_SIGN_BENCH_APP=path` points it at an existing .app.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,3 +35,31 @@ jobs:
         run: ./spec/ci/generate-identity.sh
       - name: Test
         run: yarn build && yarn test
+  test-linux:
+    name: Test JS packaging on Linux
+    strategy:
+      matrix:
+        node-version:
+          - '22.12.x'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "${{ matrix.node-version }}"
+          cache: 'yarn'
+      - name: Install
+        run: yarn install --immutable
+      - name: Build
+        run: yarn build
+      # The JS packaging implementation is cross-platform for unsigned
+      # packages; run its unit and flat() suites (native-parity specs
+      # self-skip off macOS), then exercise the shipped CLI end-to-end.
+      - name: Test
+        run: yarn vitest run spec/pkg-utils spec/flat.spec.ts
+      - name: CLI smoke test
+        run: node spec/ci/js-flat-smoke.mjs

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Notes on intentional differences from the native tools:
   zlib flavor; decompressed content is identical.
 - Extended attributes are not preserved (no AppleDouble `._*` entries are generated).
 - The app's `Info.plist` must be XML; binary property lists are rejected with an error.
+- Hardlinked files are stored as independent copies rather than deduplicated the way
+  pkgbuild archives them (Electron apps use symlinks, not hardlinks).
 - Individual files larger than 4 GB are rejected (the flat package Bom format stores
   32-bit sizes; `Size64` support is not implemented).
 - Files with NFC-normalized (composed) Unicode names are packaged correctly; native

--- a/README.md
+++ b/README.md
@@ -202,6 +202,42 @@ flat({
 The only mandatory option for `flat` is a path to your `.app` package.
 For full configuration options, see the [API documentation].
 
+### Pure-JavaScript packaging
+
+By default `flat` shells out to Apple's `pkgbuild`/`productbuild` binaries. Passing
+`implementation: 'js'` switches to a bundled pure-JavaScript implementation of the
+flat package format that is typically **4–5× faster** on a real Electron app and works
+on any platform (Linux/Windows included) for unsigned packages:
+
+```javascript
+await flat({
+  app: 'path/to/my.app',
+  implementation: 'js',
+});
+```
+
+The JS implementation reimplements the entire flat package stack — the cpio payload
+archive, Apple's Bill-of-Materials (`Bom`) binary format, the `PackageInfo`/`Distribution`
+documents and the outer xar archive. Its output is verified against the native tools by
+an extensive parity test suite (`spec/pkg-utils/`): uncompressed payloads are
+byte-identical, `lsbom` output matches on every field, and the XML documents are
+byte-identical modulo the `generator-version` attribute. Run `yarn bench` to reproduce
+the performance comparison on your machine.
+
+Notes on intentional differences from the native tools:
+
+- The payload is gzip-compressed as a standards-compliant multi-member stream so members
+  can be compressed in parallel. Compressed output is ~3% larger than Apple's private
+  zlib flavor; decompressed content is identical.
+- Extended attributes are not preserved (no AppleDouble `._*` entries are generated).
+- The app's `Info.plist` must be XML; binary property lists are rejected with an error.
+- Individual files larger than 4 GB are rejected (the flat package Bom format stores
+  32-bit sizes; `Size64` support is not implemented).
+- Files with NFC-normalized (composed) Unicode names are packaged correctly; native
+  `pkgbuild` silently omits such files from the payload.
+- When a signing `identity` is provided, the built package is signed with `productsign`,
+  which requires macOS.
+
 ## CLI
 
 `@electron/osx-sign` also exposes a legacy command-line interface (CLI) for both signing

--- a/bin/electron-osx-flat-usage.txt
+++ b/bin/electron-osx-flat-usage.txt
@@ -20,6 +20,11 @@ DESCRIPTION
   --identityValidation, --no-identityValidation
     Flag to enable/disable validation for the signing identity.
 
+  --implementation=implementation
+    Packaging implementation to use.
+    Allowed values: ``native'' (Apple's pkgbuild/productbuild), ``js'' (bundled pure-JavaScript implementation; faster and cross-platform for unsigned packages).
+    Default to ``native''.
+
   --install=install-path
     Path to install the bundle.
     Default to ``/Applications''.

--- a/bin/electron-osx-flat-usage.txt
+++ b/bin/electron-osx-flat-usage.txt
@@ -38,6 +38,10 @@ DESCRIPTION
     Allowed values: ``darwin'', ``mas''.
     Default to auto detect from application bundle.
 
+  --noIdentity
+    Flag to build an unsigned package, skipping signing identity discovery.
+    Required for building with ``--implementation=js'' on non-macOS platforms.
+
   --pkg
     Path to the output the flattened package.
     Needs file extension ``.pkg''.

--- a/bin/electron-osx-flat.mjs
+++ b/bin/electron-osx-flat.mjs
@@ -14,6 +14,12 @@ const { values, positionals } = parseArgs({
     identity: {
       type: 'string',
     },
+    implementation: {
+      type: 'string',
+    },
+    install: {
+      type: 'string',
+    },
     identityValidation: {
       type: 'boolean',
       default: false,

--- a/bin/electron-osx-flat.mjs
+++ b/bin/electron-osx-flat.mjs
@@ -20,6 +20,10 @@ const { values, positionals } = parseArgs({
     install: {
       type: 'string',
     },
+    noIdentity: {
+      type: 'boolean',
+      default: false,
+    },
     identityValidation: {
       type: 'boolean',
       default: false,
@@ -46,7 +50,11 @@ const { values, positionals } = parseArgs({
 
 const app = positionals.shift();
 
-const { help, ...opts } = values;
+const { help, noIdentity, ...opts } = values;
+if (noIdentity) {
+  // identity: null skips identity discovery and signing entirely.
+  opts.identity = null;
+}
 
 if (!app || help || positionals.length > 0) {
   const usage = fs

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "scripts": {
     "build": "tsc",
     "build:docs": "typedoc",
+    "bench": "yarn build && node spec/bench/pkg-benchmark.mjs",
     "lint": "oxfmt --check . && oxlint",
     "lint:fix": "oxfmt --write . && oxlint --fix",
     "test": "vitest run",

--- a/spec/bench/pkg-benchmark.mjs
+++ b/spec/bench/pkg-benchmark.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+/**
+ * Benchmark: pure-JS flat package builder vs Apple's native
+ * pkgbuild/productbuild.
+ *
+ * Usage:
+ *   yarn bench                        # downloads Electron and benchmarks it
+ *   OSX_SIGN_BENCH_APP=path yarn bench  # benchmark a specific .app
+ *   OSX_SIGN_BENCH_RUNS=5 yarn bench    # runs per pipeline (default 3)
+ *   OSX_SIGN_BENCH_SYNTHETIC=400 yarn bench  # use a synthetic app of ~400 MB
+ *
+ * On macOS the native pipelines run for comparison and the JS payload is
+ * verified byte-identical against the native one. On other platforms only
+ * the JS pipelines run (native tools do not exist there).
+ */
+
+import { execFileSync, execFile } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import { promisify } from 'node:util';
+
+import { buildProductArchive } from '../../dist/pkg-utils/pkg.js';
+import { readXar } from '../../dist/pkg-utils/xar.js';
+
+const RUNS = Number(process.env.OSX_SIGN_BENCH_RUNS ?? 3);
+const isDarwin = process.platform === 'darwin';
+
+function hasCommand(cmd) {
+  try {
+    execFileSync('/usr/bin/which', [cmd], { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const nativeAvailable = isDarwin && hasCommand('pkgbuild') && hasCommand('productbuild');
+
+// ---------------------------------------------------------------------------
+// App acquisition
+// ---------------------------------------------------------------------------
+
+function generateSyntheticApp(root, totalMB) {
+  const app = path.join(root, 'Bench.app');
+  fs.mkdirSync(path.join(app, 'Contents', 'MacOS'), { recursive: true });
+  const fwDir = path.join(app, 'Contents', 'Frameworks', 'Bench Framework.framework');
+  fs.mkdirSync(path.join(fwDir, 'Versions', 'A'), { recursive: true });
+  fs.writeFileSync(
+    path.join(app, 'Contents', 'Info.plist'),
+    `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleIdentifier</key><string>com.example.bench</string>
+<key>CFBundleName</key><string>Bench</string>
+<key>CFBundleShortVersionString</key><string>1.0.0</string>
+<key>CFBundleVersion</key><string>100</string>
+<key>CFBundleExecutable</key><string>Bench</string>
+</dict></plist>`,
+  );
+  const fill = (buf, seed) => {
+    let state = seed >>> 0;
+    for (let i = 0; i + 4 <= buf.length; i += 4) {
+      state = (state * 1664525 + 1013904223) >>> 0;
+      // Half-repetitive content compresses like real binaries/resources do.
+      buf.writeUInt32LE((i & 8 ? state : state & 0xff0f0f0f) >>> 0, i);
+    }
+  };
+  let buf = Buffer.alloc(Math.floor(totalMB * 0.55 * 1024 * 1024));
+  fill(buf, 42);
+  buf.writeUInt32LE(0xfeedfacf, 0);
+  buf.writeUInt32LE(0x0100000c, 4); // arm64 thin Mach-O header
+  fs.writeFileSync(path.join(fwDir, 'Versions', 'A', 'Bench Framework'), buf);
+  buf = Buffer.alloc(Math.floor(totalMB * 0.15 * 1024 * 1024));
+  fill(buf, 7);
+  buf.writeUInt32LE(0xfeedfacf, 0);
+  buf.writeUInt32LE(0x0100000c, 4);
+  fs.writeFileSync(path.join(app, 'Contents', 'MacOS', 'Bench'), buf, { mode: 0o755 });
+  const files = 2500;
+  const per = Math.floor((totalMB * 0.3 * 1024 * 1024) / files);
+  for (let d = 0; d < 50; d++) {
+    const dir = path.join(app, 'Contents', 'Resources', `locale-${String(d).padStart(2, '0')}`);
+    fs.mkdirSync(dir, { recursive: true });
+    for (let f = 0; f < files / 50; f++) {
+      const b = Buffer.alloc(per + ((d * 50 + f) % 1000));
+      fill(b, d * 1000 + f);
+      fs.writeFileSync(path.join(dir, `res-${String(f).padStart(3, '0')}.pak`), b);
+    }
+  }
+  fs.symlinkSync('Versions/A/Bench Framework', path.join(fwDir, 'Bench Framework'));
+  fs.symlinkSync('A', path.join(fwDir, 'Versions', 'Current'));
+  return app;
+}
+
+async function acquireApp(workDir) {
+  if (process.env.OSX_SIGN_BENCH_APP) {
+    return { app: path.resolve(process.env.OSX_SIGN_BENCH_APP), label: 'user-provided app' };
+  }
+  if (process.env.OSX_SIGN_BENCH_SYNTHETIC) {
+    const mb = Number(process.env.OSX_SIGN_BENCH_SYNTHETIC);
+    console.log(`Generating ~${mb} MB synthetic app...`);
+    return { app: generateSyntheticApp(workDir, mb), label: `synthetic ${mb} MB app` };
+  }
+  const version = process.env.OSX_SIGN_BENCH_ELECTRON ?? '35.0.3';
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+  console.log(`Downloading Electron v${version} (darwin-${arch})...`);
+  const { downloadArtifact } = await import('@electron/get');
+  const { extract } = await import('@electron-internal/extract-zip');
+  const zip = await downloadArtifact({
+    version,
+    platform: 'darwin',
+    arch,
+    artifactName: 'electron',
+  });
+  const dir = path.join(workDir, 'electron');
+  await extract(zip, { dir });
+  return { app: path.join(dir, 'Electron.app'), label: `Electron v${version} (darwin-${arch})` };
+}
+
+// ---------------------------------------------------------------------------
+// Pipelines
+// ---------------------------------------------------------------------------
+
+const execFileAsync = promisify(execFile);
+
+async function nativePackagePipeline(app, outDir) {
+  // Exactly what @electron/osx-sign's flat() runs for non-MAS builds.
+  const component = path.join(outDir, 'native-component.pkg');
+  const product = path.join(outDir, 'native-product.pkg');
+  await execFileAsync('pkgbuild', [
+    '--install-location',
+    '/Applications',
+    '--component',
+    app,
+    component,
+  ]);
+  await execFileAsync('productbuild', ['--package', component, '/Applications', product]);
+  fs.rmSync(component);
+  return product;
+}
+
+async function nativeComponentPipeline(app, outDir) {
+  // What flat() runs for MAS builds.
+  const product = path.join(outDir, 'native-mas.pkg');
+  await execFileAsync('productbuild', ['--component', app, '/Applications', product]);
+  return product;
+}
+
+async function jsPipeline(app, outDir, compression, name) {
+  const product = path.join(outDir, name);
+  await buildProductArchive({
+    app,
+    installLocation: '/Applications',
+    output: product,
+    compression,
+  });
+  return product;
+}
+
+async function timePipeline(label, runs, fn) {
+  const times = [];
+  let output;
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now();
+    output = await fn();
+    times.push((performance.now() - start) / 1000);
+  }
+  times.sort((a, b) => a - b);
+  const median = times[Math.floor(times.length / 2)];
+  const size = fs.statSync(output).size;
+  console.log(
+    `  ${label}: median ${median.toFixed(2)}s (runs: ${times.map((t) => t.toFixed(2)).join(', ')})`,
+  );
+  return { label, median, best: times[0], size, output };
+}
+
+// ---------------------------------------------------------------------------
+// Verification
+// ---------------------------------------------------------------------------
+
+function parseCpioNames(buf) {
+  const entries = [];
+  let offset = 0;
+  while (offset < buf.length) {
+    const header = buf.subarray(offset, offset + 76).toString('latin1');
+    if (header.slice(0, 6) !== '070707') break;
+    const namesize = parseInt(header.slice(59, 65), 8);
+    const filesize = parseInt(header.slice(65, 76), 8);
+    entries.push({
+      name: buf.subarray(offset + 76, offset + 76 + namesize - 1).toString('utf8'),
+      header,
+      data: buf.subarray(offset + 76 + namesize, offset + 76 + namesize + filesize),
+    });
+    offset += 76 + namesize + filesize;
+  }
+  return entries;
+}
+
+/** Drop AppleDouble entries and renumber inodes (see pkg-parity.spec.ts). */
+function normalizePayload(buf) {
+  const entries = parseCpioNames(buf).filter(
+    (e) => !(e.name.split('/').pop() ?? '').startsWith('._'),
+  );
+  const chunks = [];
+  let written = 0;
+  entries.forEach((entry, ino) => {
+    const nameBuf = Buffer.concat([Buffer.from(entry.name, 'utf8'), Buffer.from([0])]);
+    const header =
+      entry.header.slice(0, 12) + ino.toString(8).padStart(6, '0') + entry.header.slice(18);
+    chunks.push(Buffer.from(header, 'latin1'), nameBuf, entry.data);
+    written += 76 + nameBuf.length + entry.data.length;
+  });
+  const pad = (512 - (written % 512)) % 512;
+  if (pad > 0) chunks.push(Buffer.alloc(pad));
+  return Buffer.concat(chunks);
+}
+
+async function payloadOf(pkgPath) {
+  const members = await readXar(pkgPath);
+  const payload = members.find((m) => m.path.endsWith('/Payload'));
+  return zlib.gunzipSync(payload.data);
+}
+
+// ---------------------------------------------------------------------------
+
+const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-bench-'));
+try {
+  const { app, label } = await acquireApp(workDir);
+  const stats = execFileSync('du', ['-sh', app], { encoding: 'utf8' }).split('\t')[0].trim();
+  const fileCount = fs
+    .readdirSync(app, { recursive: true, withFileTypes: true })
+    .filter((d) => d.isFile()).length;
+  console.log(`\nBenchmarking against ${label}: ${stats}, ${fileCount} files`);
+  console.log(`Runs per pipeline: ${RUNS}\n`);
+
+  const outDir = path.join(workDir, 'out');
+  fs.mkdirSync(outDir);
+
+  const results = [];
+  if (nativeAvailable) {
+    results.push(
+      await timePipeline('native pkgbuild + productbuild --package', RUNS, () =>
+        nativePackagePipeline(app, outDir),
+      ),
+    );
+    results.push(
+      await timePipeline('native productbuild --component (MAS)', RUNS, () =>
+        nativeComponentPipeline(app, outDir),
+      ),
+    );
+  } else {
+    console.log('  (native tools unavailable on this platform — JS pipelines only)');
+  }
+  results.push(
+    await timePipeline('js (parallel compression, default)', RUNS, () =>
+      jsPipeline(app, outDir, undefined, 'js-parallel.pkg'),
+    ),
+  );
+  results.push(
+    await timePipeline('js (single-stream compression)', RUNS, () =>
+      jsPipeline(app, outDir, { strategy: 'single' }, 'js-single.pkg'),
+    ),
+  );
+
+  if (nativeAvailable) {
+    process.stdout.write('\nVerifying JS payload matches the native payload... ');
+    const native = normalizePayload(await payloadOf(results[0].output));
+    const js = normalizePayload(await payloadOf(results[2].output));
+    if (Buffer.compare(native, js) !== 0) {
+      console.log('MISMATCH — benchmark outputs are not equivalent!');
+      process.exitCode = 1;
+    } else {
+      console.log(`ok (${js.length} bytes uncompressed)`);
+    }
+  }
+
+  const baseline = results[0];
+  console.log(`\n| pipeline | median | speedup | output size |`);
+  console.log(`| --- | --- | --- | --- |`);
+  for (const result of results) {
+    console.log(
+      `| ${result.label} | ${result.median.toFixed(2)}s | ${(baseline.median / result.median).toFixed(2)}x | ${(result.size / 1e6).toFixed(1)} MB |`,
+    );
+  }
+} finally {
+  fs.rmSync(workDir, { recursive: true, force: true });
+}

--- a/spec/bench/pkg-benchmark.mjs
+++ b/spec/bench/pkg-benchmark.mjs
@@ -252,21 +252,15 @@ try {
   } else {
     console.log('  (native tools unavailable on this platform — JS pipelines only)');
   }
-  results.push(
-    await timePipeline('js (parallel compression, default)', RUNS, () =>
-      jsPipeline(app, outDir, undefined, 'js-parallel.pkg'),
-    ),
+  const jsResult = await timePipeline('js implementation', RUNS, () =>
+    jsPipeline(app, outDir, undefined, 'js.pkg'),
   );
-  results.push(
-    await timePipeline('js (single-stream compression)', RUNS, () =>
-      jsPipeline(app, outDir, { strategy: 'single' }, 'js-single.pkg'),
-    ),
-  );
+  results.push(jsResult);
 
   if (nativeAvailable) {
     process.stdout.write('\nVerifying JS payload matches the native payload... ');
     const native = normalizePayload(await payloadOf(results[0].output));
-    const js = normalizePayload(await payloadOf(results[2].output));
+    const js = normalizePayload(await payloadOf(jsResult.output));
     if (Buffer.compare(native, js) !== 0) {
       console.log('MISMATCH — benchmark outputs are not equivalent!');
       process.exitCode = 1;

--- a/spec/bench/pkg-benchmark.mjs
+++ b/spec/bench/pkg-benchmark.mjs
@@ -102,7 +102,7 @@ async function acquireApp(workDir) {
     console.log(`Generating ~${mb} MB synthetic app...`);
     return { app: generateSyntheticApp(workDir, mb), label: `synthetic ${mb} MB app` };
   }
-  const version = process.env.OSX_SIGN_BENCH_ELECTRON ?? '35.0.3';
+  const version = process.env.OSX_SIGN_BENCH_ELECTRON ?? '43.1.0';
   const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
   console.log(`Downloading Electron v${version} (darwin-${arch})...`);
   const { downloadArtifact } = await import('@electron/get');

--- a/spec/ci/js-flat-smoke.mjs
+++ b/spec/ci/js-flat-smoke.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform smoke test for the JS packaging implementation via the
+ * shipped CLI: builds a fixture app into a .pkg with `electron-osx-flat
+ * --implementation=js`, then reads the archive back and checks the payload.
+ * Run after `yarn build`; exits non-zero on any mismatch.
+ */
+
+import assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import zlib from 'node:zlib';
+
+import { readXar } from '../../dist/pkg-utils/xar.js';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'js-flat-smoke-'));
+try {
+  const app = path.join(tmp, 'parent', 'Smoke.app');
+  fs.mkdirSync(path.join(app, 'Contents', 'MacOS'), { recursive: true });
+  fs.mkdirSync(path.join(app, 'Contents', 'Resources'), { recursive: true });
+  fs.writeFileSync(
+    path.join(app, 'Contents', 'Info.plist'),
+    `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleIdentifier</key><string>com.example.smoke</string>
+<key>CFBundleName</key><string>Smoke</string>
+<key>CFBundleShortVersionString</key><string>1.0.0</string>
+<key>CFBundleVersion</key><string>100</string>
+</dict></plist>`,
+  );
+  fs.writeFileSync(path.join(app, 'Contents', 'MacOS', 'Smoke'), '#!/bin/sh\necho hi\n', {
+    mode: 0o755,
+  });
+  fs.writeFileSync(path.join(app, 'Contents', 'Resources', 'data.txt'), 'smoke test payload');
+  fs.symlinkSync('data.txt', path.join(app, 'Contents', 'Resources', 'link'));
+
+  const pkg = path.join(tmp, 'Smoke.pkg');
+  const cli = path.join(import.meta.dirname, '..', '..', 'bin', 'electron-osx-flat.mjs');
+  execFileSync(
+    process.execPath,
+    [cli, app, '--implementation=js', '--noIdentity', '--platform=darwin', `--pkg=${pkg}`],
+    { stdio: 'inherit' },
+  );
+
+  const members = await readXar(pkg);
+  const memberOf = (p) => members.find((m) => m.path === p)?.data;
+  assert.ok(memberOf('Distribution'), 'Distribution missing');
+  assert.ok(memberOf('Smoke-component.pkg/Bom'), 'Bom missing');
+  const packageInfo = memberOf('Smoke-component.pkg/PackageInfo').toString('utf8');
+  assert.match(packageInfo, /identifier="com\.example\.smoke"/);
+  assert.match(packageInfo, /numberOfFiles="8"/);
+
+  const payload = zlib.gunzipSync(memberOf('Smoke-component.pkg/Payload'));
+  const text = payload.toString('latin1');
+  for (const expected of [
+    './Smoke.app/Contents/MacOS/Smoke',
+    './Smoke.app/Contents/Resources/data.txt',
+    './Smoke.app/Contents/Resources/link',
+    'smoke test payload',
+    'TRAILER!!!',
+  ]) {
+    assert.ok(text.includes(expected), `payload missing: ${expected}`);
+  }
+  assert.strictEqual(payload.length % 512, 0, 'payload not block-padded');
+
+  console.log(`ok: built and validated ${pkg} on ${process.platform}`);
+} finally {
+  fs.rmSync(tmp, { recursive: true, force: true });
+}

--- a/spec/flat.spec.ts
+++ b/spec/flat.spec.ts
@@ -1,3 +1,125 @@
-import { describe } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import zlib from 'node:zlib';
 
-describe.todo('flat');
+import { flat } from '../src/index.js';
+import { readXar } from '../src/pkg-utils/xar.js';
+import { readBom } from '../src/pkg-utils/bom-reader.js';
+import { commandExists, infoPlist, parseCpio, writeFixtureTree } from './pkg-utils/helpers.js';
+
+const hasPkgutil = process.platform === 'darwin' && commandExists('pkgutil');
+
+describe('flat (js implementation)', () => {
+  let tmp: string;
+  let app: string;
+
+  beforeAll(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'flat-js-'));
+    const parent = path.join(tmp, 'parent');
+    writeFixtureTree(parent, [
+      { path: 'Flat.app/Contents/Info.plist', content: infoPlist('com.example.flat') },
+      { path: 'Flat.app/Contents/MacOS/Fixture', content: '#!/bin/sh\n', mode: 0o755 },
+      { path: 'Flat.app/Contents/Resources/data.txt', content: 'data' },
+    ]);
+    app = path.join(parent, 'Flat.app');
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('builds an unsigned pkg on any platform', async () => {
+    const pkg = path.join(tmp, 'out', 'flat.pkg');
+    fs.mkdirSync(path.dirname(pkg), { recursive: true });
+    await flat({ app, pkg, identity: null, platform: 'darwin', implementation: 'js' });
+    const members = await readXar(pkg);
+    const paths = members.map((m) => m.path);
+    expect(paths).toContain('Distribution');
+    expect(paths).toContain('Flat-component.pkg/Payload');
+    expect(paths).toContain('Flat-component.pkg/PackageInfo');
+    expect(paths).toContain('Flat-component.pkg/Bom');
+
+    if (hasPkgutil) {
+      const expanded = path.join(tmp, 'out', 'expanded');
+      execFileSync('pkgutil', ['--expand-full', pkg, expanded], { stdio: 'pipe' });
+      expect(
+        fs.readFileSync(
+          path.join(
+            expanded,
+            'Flat-component.pkg',
+            'Payload',
+            'Flat.app',
+            'Contents',
+            'Resources',
+            'data.txt',
+          ),
+          'utf8',
+        ),
+      ).toBe('data');
+    }
+  });
+
+  it('builds a mas-style pkg with the identifier as the embedded name', async () => {
+    const pkg = path.join(tmp, 'out-mas', 'flat.pkg');
+    fs.mkdirSync(path.dirname(pkg), { recursive: true });
+    await flat({ app, pkg, identity: null, platform: 'mas', implementation: 'js' });
+    const members = await readXar(pkg);
+    expect(members.map((m) => m.path)).toContain('com.example.flat.pkg/Payload');
+    const packageInfo = members
+      .find((m) => m.path === 'com.example.flat.pkg/PackageInfo')!
+      .data!.toString('utf8');
+    expect(packageInfo).toContain('preserve-xattr="true"');
+  });
+
+  it('overwrites an existing output package', async () => {
+    // Regression guard for rebuild loops: the second build must replace the
+    // first (productsign also refuses existing destinations; the js path
+    // removes the output before signing).
+    const pkg = path.join(tmp, 'out-twice', 'flat.pkg');
+    fs.mkdirSync(path.dirname(pkg), { recursive: true });
+    await flat({ app, pkg, identity: null, platform: 'darwin', implementation: 'js' });
+    const firstSize = fs.statSync(pkg).size;
+    await flat({ app, pkg, identity: null, platform: 'darwin', implementation: 'js' });
+    expect(fs.statSync(pkg).size).toBeGreaterThan(0);
+    expect(Math.abs(fs.statSync(pkg).size - firstSize)).toBeLessThan(1024);
+  });
+
+  it('applies squirrel-friendly permissions when requested', async () => {
+    // The app's parent directory mode feeds the payload root entry; make it
+    // something other than 755 to prove the root is forced to 0775 like the
+    // legacy setPermissionOnBom rewrite guarantees.
+    fs.chmodSync(path.dirname(app), 0o700);
+    const pkg = path.join(tmp, 'out-squirrel', 'flat.pkg');
+    fs.mkdirSync(path.dirname(pkg), { recursive: true });
+    await flat({
+      app,
+      pkg,
+      identity: null,
+      platform: 'darwin',
+      implementation: 'js',
+      openPermissionsForSquirrelMac: true,
+    });
+    const members = await readXar(pkg);
+    const payload = zlib.gunzipSync(members.find((m) => m.path.endsWith('/Payload'))!.data!);
+    const entries = parseCpio(payload).filter((e) => e.name !== 'TRAILER!!!');
+    const byName = new Map(entries.map((e) => [e.name, e]));
+    // The payload root is forced to 0775 regardless of the staging
+    // directory's permissions (here 0700).
+    expect(byName.get('.')!.mode & 0o7777).toBe(0o775);
+    expect(byName.get('./Flat.app')!.mode & 0o7777).toBe(0o775);
+    expect(byName.get('./Flat.app/Contents/MacOS/Fixture')!.mode & 0o7777).toBe(0o775);
+    expect(byName.get('./Flat.app/Contents/Resources/data.txt')!.mode & 0o7777).toBe(0o664);
+    for (const entry of entries) {
+      expect(entry.gid, entry.name).toBe(80);
+      expect(entry.uid, entry.name).toBe(0);
+    }
+    const bom = readBom(members.find((m) => m.path.endsWith('/Bom'))!.data!);
+    for (const bomPath of bom.paths) {
+      if (bomPath.path === '.') continue;
+      expect(bomPath.gid, bomPath.path).toBe(80);
+    }
+  });
+});

--- a/spec/pkg-utils/helpers.ts
+++ b/spec/pkg-utils/helpers.ts
@@ -1,0 +1,189 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** Parsed entry of a cpio odc archive. */
+export interface ParsedCpioEntry {
+  name: string;
+  dev: number;
+  ino: number;
+  mode: number;
+  uid: number;
+  gid: number;
+  nlink: number;
+  rdev: number;
+  mtime: number;
+  data: Buffer;
+}
+
+export function parseCpio(buf: Buffer): ParsedCpioEntry[] {
+  const entries: ParsedCpioEntry[] = [];
+  let offset = 0;
+  while (offset < buf.length) {
+    const header = buf.subarray(offset, offset + 76).toString('latin1');
+    if (header.slice(0, 6) !== '070707') {
+      // Trailing zero padding
+      const rest = buf.subarray(offset);
+      if (!rest.every((b) => b === 0)) {
+        throw new Error(`Invalid cpio data at offset ${offset}`);
+      }
+      break;
+    }
+    const namesize = parseInt(header.slice(59, 65), 8);
+    const filesize = parseInt(header.slice(65, 76), 8);
+    const name = buf.subarray(offset + 76, offset + 76 + namesize - 1).toString('utf8');
+    const data = buf.subarray(offset + 76 + namesize, offset + 76 + namesize + filesize);
+    entries.push({
+      name,
+      dev: parseInt(header.slice(6, 12), 8),
+      ino: parseInt(header.slice(12, 18), 8),
+      mode: parseInt(header.slice(18, 24), 8),
+      uid: parseInt(header.slice(24, 30), 8),
+      gid: parseInt(header.slice(30, 36), 8),
+      nlink: parseInt(header.slice(36, 42), 8),
+      rdev: parseInt(header.slice(42, 48), 8),
+      mtime: parseInt(header.slice(48, 59), 8),
+      data: Buffer.from(data),
+    });
+    offset += 76 + namesize + filesize;
+  }
+  return entries;
+}
+
+function isAppleDouble(name: string): boolean {
+  return (name.split('/').pop() ?? '').startsWith('._');
+}
+
+/**
+ * Serialize parsed entries back to cpio bytes with sequential inodes. Used to
+ * normalize native payloads: environments that stamp com.apple.provenance
+ * xattrs make pkgbuild emit AppleDouble (`._`) entries which our
+ * implementation intentionally does not produce. Dropping them and
+ * renumbering inodes yields the byte stream pkgbuild produces on a machine
+ * without those xattrs.
+ */
+export function normalizeCpio(buf: Buffer): Buffer {
+  const entries = parseCpio(buf).filter((e) => !isAppleDouble(e.name));
+  const chunks: Buffer[] = [];
+  let written = 0;
+  entries.forEach((entry, ino) => {
+    const nameBuf = Buffer.concat([Buffer.from(entry.name, 'utf8'), Buffer.from([0])]);
+    const header =
+      '070707' +
+      entry.dev.toString(8).padStart(6, '0') +
+      ino.toString(8).padStart(6, '0') +
+      entry.mode.toString(8).padStart(6, '0') +
+      entry.uid.toString(8).padStart(6, '0') +
+      entry.gid.toString(8).padStart(6, '0') +
+      entry.nlink.toString(8).padStart(6, '0') +
+      entry.rdev.toString(8).padStart(6, '0') +
+      entry.mtime.toString(8).padStart(11, '0') +
+      nameBuf.length.toString(8).padStart(6, '0') +
+      entry.data.length.toString(8).padStart(11, '0');
+    chunks.push(Buffer.from(header, 'latin1'), nameBuf, entry.data);
+    written += 76 + nameBuf.length + entry.data.length;
+  });
+  const padding = (512 - (written % 512)) % 512;
+  if (padding > 0) chunks.push(Buffer.alloc(padding));
+  return Buffer.concat(chunks);
+}
+
+/** Run lsbom and return sorted lines, with AppleDouble entries removed. */
+export function lsbomNormalized(bomPath: string, args: string[] = []): string[] {
+  const out = execFileSync('lsbom', [...args, bomPath], { encoding: 'utf8' });
+  return out
+    .split('\n')
+    .filter((line) => line.trim().length > 0 && !isAppleDouble(line.split('\t')[0]))
+    .sort();
+}
+
+/** Strip fields that legitimately differ between the two implementations. */
+export function normalizeGeneratorVersion(xml: string): string {
+  return xml.replace(/generator-version="[^"]*"/, 'generator-version="NORMALIZED"');
+}
+
+export interface FixtureFile {
+  path: string;
+  content?: Buffer | string;
+  mode?: number;
+  symlink?: string;
+  directory?: boolean;
+  /** Seconds since epoch; also applied to files without an explicit value. */
+  mtime?: number;
+}
+
+export const FIXTURE_EPOCH = 1700000000;
+
+/**
+ * Materialize a fixture app under `root`. Directories get deterministic
+ * mtimes applied bottom-up so parent timestamps survive child creation.
+ */
+export function writeFixtureTree(root: string, files: FixtureFile[]): void {
+  const dirs = new Set<string>([root]);
+  for (const file of files) {
+    const target = path.join(root, file.path);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    let dir = path.dirname(target);
+    while (dir.length >= root.length) {
+      dirs.add(dir);
+      dir = path.dirname(dir);
+    }
+    if (file.directory) {
+      fs.mkdirSync(target, { recursive: true });
+      dirs.add(target);
+    } else if (file.symlink !== undefined) {
+      fs.symlinkSync(file.symlink, target);
+    } else {
+      fs.writeFileSync(target, file.content ?? '');
+      if (file.mode !== undefined) fs.chmodSync(target, file.mode);
+    }
+    if (!file.directory && file.symlink === undefined) {
+      const when = new Date((file.mtime ?? FIXTURE_EPOCH) * 1000);
+      fs.utimesSync(target, when, when);
+    }
+  }
+  // Apply directory mtimes deepest-first so they stick.
+  const when = new Date(FIXTURE_EPOCH * 1000);
+  [...dirs]
+    .sort((a, b) => b.length - a.length)
+    .forEach((dir) => {
+      fs.utimesSync(dir, when, when);
+    });
+}
+
+export function commandExists(command: string): boolean {
+  try {
+    execFileSync('/usr/bin/which', [command], { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const INFO_PLIST = (
+  identifier: string,
+  extra: Record<string, string>,
+): string => `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+\t<key>CFBundleIdentifier</key>
+\t<string>${identifier}</string>
+${Object.entries(extra)
+  .map(([key, value]) => `\t<key>${key}</key>\n\t<string>${value}</string>`)
+  .join('\n')}
+</dict>
+</plist>
+`;
+
+export function infoPlist(
+  identifier: string,
+  extra: Record<string, string> = {
+    CFBundleName: 'Fixture',
+    CFBundleShortVersionString: '1.2.3',
+    CFBundleVersion: '123',
+    CFBundleExecutable: 'Fixture',
+  },
+): string {
+  return INFO_PLIST(identifier, extra);
+}

--- a/spec/pkg-utils/pkg-parity-electron.spec.ts
+++ b/spec/pkg-utils/pkg-parity-electron.spec.ts
@@ -25,7 +25,7 @@ import {
 const hasNativeTools =
   process.platform === 'darwin' && ['productbuild', 'lsbom', 'xar'].every(commandExists);
 
-const ELECTRON_VERSION = '35.0.3';
+const ELECTRON_VERSION = '43.1.0';
 const WORK_CWD = path.join(import.meta.dirname, '..', 'work-pkg-electron');
 
 describe.runIf(hasNativeTools)('pkg parity with a real Electron.app', () => {

--- a/spec/pkg-utils/pkg-parity-electron.spec.ts
+++ b/spec/pkg-utils/pkg-parity-electron.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import zlib from 'node:zlib';
+
+import { extract } from '@electron-internal/extract-zip';
+import { downloadArtifact } from '@electron/get';
+
+import { buildProductArchive } from '../../src/pkg-utils/pkg.js';
+import { readXar } from '../../src/pkg-utils/xar.js';
+import {
+  commandExists,
+  lsbomNormalized,
+  normalizeCpio,
+  normalizeGeneratorVersion,
+} from './helpers.js';
+
+/**
+ * End-to-end parity against a real Electron.app — the exact artifact this
+ * library packages in production. Compares the pure-JS product archive with
+ * `productbuild --component` output member by member.
+ */
+
+const hasNativeTools =
+  process.platform === 'darwin' && ['productbuild', 'lsbom', 'xar'].every(commandExists);
+
+const ELECTRON_VERSION = '35.0.3';
+const WORK_CWD = path.join(import.meta.dirname, '..', 'work-pkg-electron');
+
+describe.runIf(hasNativeTools)('pkg parity with a real Electron.app', () => {
+  let app: string;
+  let nativePkg: string;
+  let jsPkg: string;
+
+  beforeAll(async () => {
+    const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+    const artifact = await downloadArtifact({
+      version: ELECTRON_VERSION,
+      platform: 'darwin',
+      arch,
+      artifactName: 'electron',
+    });
+    const dir = path.join(WORK_CWD, `v${ELECTRON_VERSION}-${arch}`);
+    await extract(artifact, { dir });
+    app = path.join(dir, 'Electron.app');
+
+    const outDir = path.join(WORK_CWD, 'out');
+    fs.mkdirSync(outDir, { recursive: true });
+    nativePkg = path.join(outDir, 'native.pkg');
+    jsPkg = path.join(outDir, 'js.pkg');
+    execFileSync('productbuild', ['--component', app, '/Applications', nativePkg], {
+      stdio: 'pipe',
+    });
+    await buildProductArchive({ app, installLocation: '/Applications', output: jsPkg });
+  }, 300_000);
+
+  afterAll(async () => {
+    await fs.promises.rm(WORK_CWD, { recursive: true, force: true });
+  });
+
+  it('expands with pkgutil back to the original app', () => {
+    // The Electron payload spans many parallel compression chunks; Apple's
+    // extractor must accept the stitched gzip stream and reproduce the tree.
+    const expanded = path.join(WORK_CWD, 'expanded');
+    execFileSync('pkgutil', ['--expand-full', jsPkg, expanded], { stdio: 'pipe' });
+    const payloadDir = fs.readdirSync(expanded).find((d) => d.endsWith('.pkg'))!;
+    execFileSync('diff', ['-r', app, path.join(expanded, payloadDir, 'Payload', 'Electron.app')], {
+      stdio: 'pipe',
+    });
+  });
+
+  it('produces a byte-identical uncompressed payload', async () => {
+    const nativeDir = fs.mkdtempSync(path.join(WORK_CWD, 'nx-'));
+    execFileSync('xar', ['-xf', nativePkg], { cwd: nativeDir });
+    const embedded = fs.readdirSync(nativeDir).find((d) => d.endsWith('.pkg'))!;
+    const native = normalizeCpio(
+      zlib.gunzipSync(fs.readFileSync(path.join(nativeDir, embedded, 'Payload'))),
+    );
+    const members = await readXar(jsPkg);
+    const js = zlib.gunzipSync(members.find((m) => m.path === `${embedded}/Payload`)!.data!);
+    expect(js.length).toBe(native.length);
+    expect(Buffer.compare(native, js)).toBe(0);
+  });
+
+  it('produces identical PackageInfo, Distribution and lsbom output', async () => {
+    const nativeDir = fs.mkdtempSync(path.join(WORK_CWD, 'nx2-'));
+    execFileSync('xar', ['-xf', nativePkg], { cwd: nativeDir });
+    const embedded = fs.readdirSync(nativeDir).find((d) => d.endsWith('.pkg'))!;
+    const members = await readXar(jsPkg);
+    const memberOf = (p: string) => members.find((m) => m.path === p)!.data!;
+
+    expect(normalizeGeneratorVersion(memberOf(`${embedded}/PackageInfo`).toString('utf8'))).toBe(
+      normalizeGeneratorVersion(
+        fs.readFileSync(path.join(nativeDir, embedded, 'PackageInfo'), 'utf8'),
+      ),
+    );
+    expect(normalizeGeneratorVersion(memberOf('Distribution').toString('utf8'))).toBe(
+      normalizeGeneratorVersion(fs.readFileSync(path.join(nativeDir, 'Distribution'), 'utf8')),
+    );
+
+    const jsBomPath = path.join(nativeDir, 'js-Bom');
+    fs.writeFileSync(jsBomPath, memberOf(`${embedded}/Bom`));
+    expect(lsbomNormalized(jsBomPath)).toEqual(
+      lsbomNormalized(path.join(nativeDir, embedded, 'Bom')),
+    );
+  });
+});
+
+describe.runIf(!hasNativeTools)('pkg parity with a real Electron.app (skipped)', () => {
+  it('requires macOS with the native packaging tools installed', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/spec/pkg-utils/pkg-parity.spec.ts
+++ b/spec/pkg-utils/pkg-parity.spec.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import zlib from 'node:zlib';
+
+import { buildComponentPackageFile, buildProductArchive } from '../../src/pkg-utils/pkg.js';
+import { readXar } from '../../src/pkg-utils/xar.js';
+import { readBom } from '../../src/pkg-utils/bom-reader.js';
+import {
+  commandExists,
+  FixtureFile,
+  infoPlist,
+  lsbomNormalized,
+  normalizeCpio,
+  normalizeGeneratorVersion,
+  writeFixtureTree,
+} from './helpers.js';
+
+/**
+ * Byte/semantic parity between the pure-JS packager and Apple's native
+ * pkgbuild/productbuild:
+ *
+ * - Payload/Scripts: byte-identical uncompressed cpio streams.
+ * - PackageInfo/Distribution: byte-identical modulo the generator-version
+ *   attribute (which encodes the tool version on both sides).
+ * - Bom: identical lsbom output for every printable field, identical BomInfo
+ *   size accounting, and identical B-tree entry ordering.
+ * - The JS-built package must be readable by Apple's own tooling
+ *   (xar, pkgutil --expand-full) and expand to the original app tree.
+ *
+ * AppleDouble (`._*`) entries are filtered from the native output before
+ * comparison: on hosts where the sandbox stamps com.apple.provenance xattrs
+ * onto fixture files, pkgbuild archives those as AppleDouble entries, which
+ * the JS implementation intentionally does not reproduce (xattr preservation
+ * is out of scope). On xattr-free hosts the filter is a no-op and the
+ * comparison is a straight byte-for-byte check.
+ */
+
+const isDarwin = process.platform === 'darwin';
+const hasNativeTools =
+  isDarwin && ['pkgbuild', 'productbuild', 'lsbom', 'xar', 'pkgutil'].every(commandExists);
+
+interface Fixture {
+  name: string;
+  bundleName: string;
+  files: FixtureFile[];
+  scripts?: FixtureFile[];
+}
+
+function pseudoRandom(bytes: number, seed: number): Buffer {
+  // Deterministic filler that does not compress trivially.
+  const buf = Buffer.allocUnsafe(bytes);
+  let state = seed >>> 0;
+  for (let i = 0; i < bytes; i++) {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    buf[i] = state >>> 24;
+  }
+  return buf;
+}
+
+const FIXTURES: Fixture[] = [
+  {
+    name: 'simple app',
+    bundleName: 'Simple.app',
+    files: [
+      {
+        path: 'Simple.app/Contents/Info.plist',
+        content: infoPlist('com.example.simple', {
+          CFBundleName: 'Simple',
+          CFBundleShortVersionString: '1.2.3',
+          CFBundleVersion: '123',
+          CFBundleExecutable: 'Fixture',
+          LSMinimumSystemVersion: '11.0',
+        }),
+      },
+      { path: 'Simple.app/Contents/MacOS/Fixture', content: '#!/bin/sh\necho hi\n', mode: 0o755 },
+      { path: 'Simple.app/Contents/Resources/data.txt', content: 'hello resource' },
+    ],
+  },
+  {
+    name: 'symlinks, empty dirs and odd modes',
+    bundleName: 'Odd.app',
+    files: [
+      {
+        path: 'Odd.app/Contents/Info.plist',
+        content: infoPlist('com.example.odd', { CFBundleShortVersionString: '1.0' }),
+      },
+      { path: 'Odd.app/Contents/Resources/secret.txt', content: 'shh', mode: 0o600 },
+      { path: 'Odd.app/Contents/Resources/exec-only', content: 'x', mode: 0o711 },
+      { path: 'Odd.app/Contents/Resources/rel-link', symlink: '../Info.plist' },
+      { path: 'Odd.app/Contents/Resources/abs-link', symlink: '/usr/lib/libz.dylib' },
+      { path: 'Odd.app/Contents/Resources/empty-dir', directory: true },
+      { path: 'Odd.app/Contents/Resources/empty-file', content: '' },
+      { path: 'Odd.app/Contents/Frameworks/Deep/Nested/Tree/leaf.txt', content: 'leaf' },
+    ],
+  },
+  (() => {
+    // Unicode names are written in NFD (decomposed) form: native pkgbuild
+    // *silently drops* NFC-named files from the payload (while still listing
+    // them in the Bom), so NFC names cannot be byte-compared against it. Our
+    // implementation packages NFC names correctly — see the data-loss
+    // regression test in pkg-units.spec.ts. An em dash in the bundle name is
+    // avoided for the same reason: pkgbuild emits an empty payload for those.
+    // normalize('NFD') guards against editors/formatters recomposing the literal
+    const bundle = 'Ünicode “app”.app'.normalize('NFD');
+    return {
+      name: 'unicode and sort-hostile names',
+      bundleName: bundle,
+      files: [
+        { path: `${bundle}/Contents/Info.plist`, content: infoPlist('com.example.unicode') },
+        { path: `${bundle}/Contents/Resources/Z-upper.txt`, content: 'Z' },
+        { path: `${bundle}/Contents/Resources/a-lower.txt`, content: 'a' },
+        { path: `${bundle}/Contents/Resources/émoji 🎁.txt`.normalize('NFD'), content: 'gift' },
+        { path: `${bundle}/Contents/Resources/foo`, directory: true },
+        { path: `${bundle}/Contents/Resources/foo/x.txt`, content: 'x' },
+        { path: `${bundle}/Contents/Resources/foo.txt`, content: 'prefix-hostile' },
+        { path: `${bundle}/Contents/Resources/名前.txt`.normalize('NFD'), content: 'nihongo' },
+      ],
+    };
+  })(),
+  {
+    // Large enough that the payload spans multiple parallel compression
+    // chunks (> 2 MB), so the expand test exercises the stitched single-member
+    // gzip stream against Apple's extractor.
+    name: 'larger tree spanning multiple bom leaves',
+    bundleName: 'Grande.app',
+    files: [
+      { path: 'Grande.app/Contents/Info.plist', content: infoPlist('com.example.grande') },
+      ...Array.from({ length: 40 }, (_, d) =>
+        Array.from({ length: 20 }, (_, f) => ({
+          path: `Grande.app/Contents/Resources/d${String(d).padStart(2, '0')}/f${String(f).padStart(2, '0')}.bin`,
+          content: pseudoRandom(((d * 20 + f) % 7) * 2048 + 1024, d * 1000 + f),
+        })),
+      ).flat(),
+    ],
+  },
+  {
+    name: 'scripts',
+    bundleName: 'Scripted.app',
+    files: [
+      { path: 'Scripted.app/Contents/Info.plist', content: infoPlist('com.example.scripted') },
+      { path: 'Scripted.app/Contents/MacOS/Fixture', content: '#!/bin/sh\n', mode: 0o755 },
+    ],
+    scripts: [
+      { path: 'preinstall', content: '#!/bin/sh\nexit 0\n', mode: 0o755 },
+      { path: 'postinstall', content: '#!/bin/sh\nexit 0\n', mode: 0o755 },
+      { path: 'extras/helper.sh', content: 'echo helper\n' },
+    ],
+  },
+];
+
+interface BuiltFixture {
+  fixture: Fixture;
+  appPath: string;
+  scriptsPath?: string;
+  nativeComponentPkg: string;
+  nativeProductPkg: string;
+  jsComponentPkg: string;
+  jsProductPkg: string;
+}
+
+describe.runIf(hasNativeTools)('pkg parity with native pkgbuild/productbuild', () => {
+  let tmp: string;
+  const built: BuiltFixture[] = [];
+
+  beforeAll(async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-parity-'));
+    for (const [index, fixture] of FIXTURES.entries()) {
+      // Each app lives alone in its own parent directory: pkgbuild derives the
+      // payload root metadata from the app's parent, so nothing else may live
+      // (or be written) there.
+      const parent = path.join(tmp, `fixture-${index}`, 'app-parent');
+      writeFixtureTree(parent, fixture.files);
+      const appPath = path.join(parent, fixture.bundleName);
+      let scriptsPath: string | undefined;
+      if (fixture.scripts) {
+        scriptsPath = path.join(tmp, `fixture-${index}`, 'scripts');
+        writeFixtureTree(scriptsPath, fixture.scripts);
+      }
+
+      const outDir = path.join(tmp, `fixture-${index}`, 'out');
+      fs.mkdirSync(outDir, { recursive: true });
+      const nativeComponentPkg = path.join(outDir, 'native-component.pkg');
+      const nativeProductPkg = path.join(outDir, 'native-product.pkg');
+      const jsComponentPkg = path.join(outDir, 'js-component.pkg');
+      const jsProductPkg = path.join(outDir, 'js-product.pkg');
+
+      const pkgbuildArgs = ['--install-location', '/Applications'];
+      if (scriptsPath) pkgbuildArgs.push('--scripts', scriptsPath);
+      execFileSync('pkgbuild', [...pkgbuildArgs, '--component', appPath, nativeComponentPkg], {
+        stdio: 'pipe',
+      });
+      execFileSync('productbuild', ['--component', appPath, '/Applications', nativeProductPkg], {
+        stdio: 'pipe',
+      });
+
+      await buildComponentPackageFile(jsComponentPkg, {
+        app: appPath,
+        installLocation: '/Applications',
+        scripts: scriptsPath,
+      });
+      await buildProductArchive({
+        app: appPath,
+        installLocation: '/Applications',
+        output: jsProductPkg,
+      });
+
+      built.push({
+        fixture,
+        appPath,
+        scriptsPath,
+        nativeComponentPkg,
+        nativeProductPkg,
+        jsComponentPkg,
+        jsProductPkg,
+      });
+    }
+  }, 300_000);
+
+  afterAll(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  async function membersOf(pkg: string): Promise<Map<string, Buffer>> {
+    const members = await readXar(pkg);
+    return new Map(
+      members.filter((m) => m.type === 'file').map((m) => [m.path, m.data ?? Buffer.alloc(0)]),
+    );
+  }
+
+  function extractNative(pkg: string): string {
+    const dir = fs.mkdtempSync(path.join(tmp, 'native-x-'));
+    execFileSync('xar', ['-xf', pkg], { cwd: dir });
+    return dir;
+  }
+
+  it('produces byte-identical payload cpio streams', async () => {
+    for (const b of built) {
+      const nativeDir = extractNative(b.nativeComponentPkg);
+      const native = normalizeCpio(
+        zlib.gunzipSync(fs.readFileSync(path.join(nativeDir, 'Payload'))),
+      );
+      const js = zlib.gunzipSync((await membersOf(b.jsComponentPkg)).get('Payload')!);
+      expect(Buffer.compare(native, js), b.fixture.name).toBe(0);
+    }
+  });
+
+  it('produces byte-identical scripts archives', async () => {
+    for (const b of built.filter((f) => f.scriptsPath)) {
+      const nativeDir = extractNative(b.nativeComponentPkg);
+      const native = normalizeCpio(
+        zlib.gunzipSync(fs.readFileSync(path.join(nativeDir, 'Scripts'))),
+      );
+      const js = zlib.gunzipSync((await membersOf(b.jsComponentPkg)).get('Scripts')!);
+      expect(Buffer.compare(native, js), b.fixture.name).toBe(0);
+    }
+  });
+
+  it('produces identical PackageInfo documents (modulo generator-version)', async () => {
+    for (const b of built) {
+      const nativeDir = extractNative(b.nativeComponentPkg);
+      const native = normalizeGeneratorVersion(
+        fs.readFileSync(path.join(nativeDir, 'PackageInfo'), 'utf8'),
+      );
+      const js = normalizeGeneratorVersion(
+        (await membersOf(b.jsComponentPkg)).get('PackageInfo')!.toString('utf8'),
+      );
+      expect(js, b.fixture.name).toBe(native);
+    }
+  });
+
+  it('produces Boms with identical lsbom output', async () => {
+    for (const b of built) {
+      const nativeDir = extractNative(b.nativeComponentPkg);
+      const jsBomPath = path.join(nativeDir, 'js-Bom');
+      fs.writeFileSync(jsBomPath, (await membersOf(b.jsComponentPkg)).get('Bom')!);
+      for (const args of [[], ['-p', 'fMUGsc'], ['-m', '-p', 'fmugtsc']]) {
+        const native = lsbomNormalized(path.join(nativeDir, 'Bom'), args);
+        const js = lsbomNormalized(jsBomPath, args);
+        expect(js, `${b.fixture.name} lsbom ${args.join(' ')}`).toEqual(native);
+      }
+    }
+  });
+
+  it('produces Boms with identical BomInfo size accounting and tree order', async () => {
+    for (const b of built) {
+      const nativeDir = extractNative(b.nativeComponentPkg);
+      const native = readBom(fs.readFileSync(path.join(nativeDir, 'Bom')));
+      const js = readBom((await membersOf(b.jsComponentPkg)).get('Bom')!);
+      expect(js.sizeSum, b.fixture.name).toBe(native.sizeSum);
+      const isAppleDouble = (p: string) => (p.split('/').pop() ?? '').startsWith('._');
+      const nativePaths = native.paths.map((p) => p.path).filter((p) => !isAppleDouble(p));
+      const jsPaths = js.paths.map((p) => p.path);
+      // Same B-tree traversal order (leaf order), not merely the same set.
+      expect(jsPaths, b.fixture.name).toEqual(nativePaths);
+      expect(js.numberOfPaths, b.fixture.name).toBe(jsPaths.length + 1);
+    }
+  });
+
+  it('produces identical Distribution documents (modulo generator-version)', async () => {
+    for (const b of built) {
+      const nativeDir = extractNative(b.nativeProductPkg);
+      const native = normalizeGeneratorVersion(
+        fs.readFileSync(path.join(nativeDir, 'Distribution'), 'utf8'),
+      );
+      const js = normalizeGeneratorVersion(
+        (await membersOf(b.jsProductPkg)).get('Distribution')!.toString('utf8'),
+      );
+      expect(js, b.fixture.name).toBe(native);
+    }
+  });
+
+  it('wraps an existing component package identically to productbuild --package', async () => {
+    const b = built[0];
+    const outDir = fs.mkdtempSync(path.join(tmp, 'pkgmode-'));
+    const nativeOut = path.join(outDir, 'native.pkg');
+    const jsOut = path.join(outDir, 'js.pkg');
+    execFileSync('productbuild', ['--package', b.nativeComponentPkg, nativeOut], {
+      stdio: 'pipe',
+    });
+    await buildProductArchive({ package: b.nativeComponentPkg, output: jsOut });
+
+    const nativeDir = extractNative(nativeOut);
+    const jsMembers = await membersOf(jsOut);
+    const embedded = path.basename(b.nativeComponentPkg);
+    expect(normalizeGeneratorVersion(jsMembers.get('Distribution')!.toString('utf8'))).toBe(
+      normalizeGeneratorVersion(fs.readFileSync(path.join(nativeDir, 'Distribution'), 'utf8')),
+    );
+    // The embedded component's members must survive the round-trip
+    // byte-identically once decompressed.
+    for (const member of ['Payload', 'PackageInfo', 'Bom']) {
+      const native = fs.readFileSync(path.join(nativeDir, embedded, member));
+      expect(Buffer.compare(native, jsMembers.get(`${embedded}/${member}`)!), member).toBe(0);
+    }
+  });
+
+  it('percent-encodes embedded package references like productbuild', async () => {
+    // Regression: Installer resolves `#name.pkg` as a URL fragment, so names
+    // with spaces (or any non-fragment character) must be percent-encoded.
+    const b = built[0];
+    const outDir = fs.mkdtempSync(path.join(tmp, 'encode-'));
+    const spacey = path.join(outDir, 'My App-component.pkg');
+    fs.copyFileSync(b.nativeComponentPkg, spacey);
+    const nativeOut = path.join(outDir, 'native.pkg');
+    const jsOut = path.join(outDir, 'js.pkg');
+    execFileSync('productbuild', ['--package', spacey, nativeOut], { stdio: 'pipe' });
+    await buildProductArchive({ package: spacey, output: jsOut });
+    const nativeDir = extractNative(nativeOut);
+    const jsMembers = await membersOf(jsOut);
+    expect(normalizeGeneratorVersion(jsMembers.get('Distribution')!.toString('utf8'))).toBe(
+      normalizeGeneratorVersion(fs.readFileSync(path.join(nativeDir, 'Distribution'), 'utf8')),
+    );
+    expect(jsMembers.get('Distribution')!.toString('utf8')).toContain('#My%20App-component.pkg');
+  });
+
+  it('builds packages Apple tooling can expand back to the original app', async () => {
+    for (const b of built) {
+      const expanded = path.join(path.dirname(b.jsProductPkg), 'expanded');
+      execFileSync('pkgutil', ['--expand-full', b.jsProductPkg, expanded], { stdio: 'pipe' });
+      const payloadDir = fs.readdirSync(expanded).find((entry) => entry.endsWith('.pkg'));
+      expect(payloadDir, b.fixture.name).toBeDefined();
+      const extractedApp = path.join(expanded, payloadDir!, 'Payload', path.basename(b.appPath));
+      // diff -r follows symlink targets; --no-dereference compares the links
+      execFileSync('diff', ['-r', '--no-dereference', b.appPath, extractedApp], {
+        stdio: 'pipe',
+      });
+      fs.rmSync(expanded, { recursive: true, force: true });
+    }
+  });
+
+  it('builds component packages xar itself can list and extract', async () => {
+    for (const b of built) {
+      const listing = execFileSync('xar', ['-tf', b.jsComponentPkg], { encoding: 'utf8' })
+        .trim()
+        .split('\n')
+        .sort();
+      const expected = ['Bom', 'PackageInfo', 'Payload'];
+      if (b.scriptsPath) expected.push('Scripts');
+      expect(listing, b.fixture.name).toEqual(expected.sort());
+    }
+  });
+});
+
+describe.runIf(!hasNativeTools)('pkg parity (skipped)', () => {
+  it('requires macOS with the native packaging tools installed', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/spec/pkg-utils/pkg-units.spec.ts
+++ b/spec/pkg-utils/pkg-units.spec.ts
@@ -1,0 +1,547 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import zlib from 'node:zlib';
+
+import { cksum } from '../../src/pkg-utils/cksum.js';
+import { walkTree, cpioOrder, bomOrder } from '../../src/pkg-utils/walk.js';
+import { cpioStream, newCpioWriteResult } from '../../src/pkg-utils/cpio-writer.js';
+import { writeBom } from '../../src/pkg-utils/bom-writer.js';
+import { readBom } from '../../src/pkg-utils/bom-reader.js';
+import { gzipStream } from '../../src/pkg-utils/gzip.js';
+import { writeXar, readXar } from '../../src/pkg-utils/xar.js';
+import { parseXml, escapeXml } from '../../src/pkg-utils/xml.js';
+import {
+  machOSliceSizes,
+  readHostArchitectures,
+  DEFAULT_HOST_ARCHITECTURES,
+} from '../../src/pkg-utils/macho.js';
+import { renderPackageInfo } from '../../src/pkg-utils/package-info.js';
+import { percentEncodeFragment, renderDistribution } from '../../src/pkg-utils/distribution.js';
+import { buildComponentPackage, normalizePackageVersion } from '../../src/pkg-utils/pkg.js';
+import { parseCpio, writeFixtureTree, infoPlist, FIXTURE_EPOCH } from './helpers.js';
+
+async function collect(source: AsyncIterable<Buffer>): Promise<Buffer> {
+  const parts: Buffer[] = [];
+  for await (const part of source) parts.push(part);
+  return Buffer.concat(parts);
+}
+
+describe('cksum', () => {
+  it('matches macOS cksum(1) reference values', () => {
+    // Reference values produced by /usr/bin/cksum on macOS.
+    expect(cksum(Buffer.from('hello'))).toBe(3287646509);
+    expect(cksum(Buffer.from('#!/bin/sh\necho hi\n'))).toBe(3783648674);
+    expect(cksum(Buffer.from('data.txt'))).toBe(4247533825);
+    expect(cksum(Buffer.alloc(0))).toBe(4294967295);
+  });
+});
+
+describe('version normalization', () => {
+  it('pads dotted numeric versions to three components like pkgbuild', () => {
+    expect(normalizePackageVersion('1.0')).toBe('1.0.0');
+    expect(normalizePackageVersion('2')).toBe('2.0.0');
+    expect(normalizePackageVersion('1.2.3')).toBe('1.2.3');
+    expect(normalizePackageVersion('1.2.3.4')).toBe('1.2.3.4');
+    expect(normalizePackageVersion('1.0-beta')).toBe('1.0-beta');
+  });
+});
+
+describe('xml', () => {
+  it('escapes attribute characters', () => {
+    expect(escapeXml('a & <b> "c"')).toBe('a &amp; &lt;b&gt; &quot;c&quot;');
+  });
+
+  it('parses and unescapes documents', () => {
+    const doc = parseXml(
+      '<?xml version="1.0"?><root a="1 &amp; 2"><child>x &lt; y</child><empty/></root>',
+    );
+    expect(doc.name).toBe('root');
+    expect(doc.attributes.a).toBe('1 & 2');
+    expect(doc.children[0].text).toBe('x < y');
+    expect(doc.children[1].name).toBe('empty');
+  });
+});
+
+describe('macho', () => {
+  function thinMachO(cpuType: number): Buffer {
+    const buf = Buffer.alloc(32);
+    buf.writeUInt32LE(0xfeedfacf, 0);
+    buf.writeUInt32LE(cpuType, 4);
+    return buf;
+  }
+
+  it('reads thin binaries', () => {
+    const sizes = machOSliceSizes(
+      Buffer.concat([Buffer.from([0xcf, 0xfa, 0xed, 0xfe]), thinMachO(0x0100000c).subarray(4)]),
+      1000,
+    );
+    expect(sizes).toEqual(new Map([[0x0100000c, 1000]]));
+  });
+
+  it('reads fat binaries per-slice', () => {
+    const fat = Buffer.alloc(8 + 2 * 20);
+    fat.writeUInt32BE(0xcafebabe, 0);
+    fat.writeUInt32BE(2, 4);
+    fat.writeUInt32BE(0x01000007, 8); // x86_64
+    fat.writeUInt32BE(4096, 8 + 8); // offset
+    fat.writeUInt32BE(300, 8 + 12); // size
+    fat.writeUInt32BE(0x0100000c, 28); // arm64
+    fat.writeUInt32BE(8192, 28 + 8);
+    fat.writeUInt32BE(500, 28 + 12);
+    const sizes = machOSliceSizes(fat, 9000);
+    expect(sizes).toEqual(
+      new Map([
+        [0x01000007, 300],
+        [0x0100000c, 500],
+      ]),
+    );
+  });
+
+  it('rejects non-Mach-O data', () => {
+    expect(machOSliceSizes(Buffer.from('#!/bin/sh\n'), 10)).toBeNull();
+  });
+
+  it('rejects Java .class files that share the fat magic', () => {
+    // Regression: 0xCAFEBABE + minor/major version (e.g. 52) parses as a
+    // plausible fat arch count; the slice bounds check must reject it.
+    const javaClass = Buffer.alloc(64);
+    javaClass.writeUInt32BE(0xcafebabe, 0);
+    javaClass.writeUInt16BE(0, 4); // minor_version
+    javaClass.writeUInt16BE(52, 6); // major_version (Java 8)
+    javaClass.fill(0x2a, 8); // constant pool garbage
+    expect(machOSliceSizes(javaClass, 5000)).toBeNull();
+  });
+
+  it('rejects fat headers whose slices fall outside the file', () => {
+    const fat = Buffer.alloc(8 + 20);
+    fat.writeUInt32BE(0xcafebabe, 0);
+    fat.writeUInt32BE(1, 4);
+    fat.writeUInt32BE(0x0100000c, 8);
+    fat.writeUInt32BE(4096, 16); // offset
+    fat.writeUInt32BE(10_000, 20); // size beyond the file
+    expect(machOSliceSizes(fat, 5000)).toBeNull();
+  });
+
+  it('falls back to the default architecture list', async () => {
+    expect(await readHostArchitectures('/nonexistent/binary')).toBe(DEFAULT_HOST_ARCHITECTURES);
+  });
+});
+
+describe('gzip', () => {
+  it('parallel output is a single-member gzip stream that decompresses to the input', async () => {
+    const input = Buffer.concat([
+      Buffer.from('a'.repeat(3 * 1024 * 1024)),
+      Buffer.from('b'.repeat(2 * 1024 * 1024)),
+    ]);
+    async function* source() {
+      for (let i = 0; i < input.length; i += 700_000) {
+        yield input.subarray(i, i + 700_000);
+      }
+    }
+    const parts = await gzipStream(source(), { chunkSize: 1024 * 1024 });
+    expect(parts.length).toBeGreaterThan(2); // header + >1 compressed chunk + trailer
+    const stream = Buffer.concat(parts);
+    // Standard single-member gzip: fixed header, exactly one member. macOS
+    // Installer's payload extractor rejects multi-member streams, so this is
+    // a hard requirement, not a style choice.
+    expect([...stream.subarray(0, 4)]).toEqual([0x1f, 0x8b, 0x08, 0x00]);
+    expect(Buffer.compare(zlib.gunzipSync(stream), input)).toBe(0);
+    // The ISIZE trailer must reflect the full stream (it would only cover the
+    // last member if this were multi-member).
+    expect(stream.readUInt32LE(stream.length - 4)).toBe(input.length);
+    expect(stream.readUInt32LE(stream.length - 8)).toBe(zlib.crc32(input) >>> 0);
+  });
+
+  it('rejects with the source error and leaves no unhandled rejections', async () => {
+    // Regression: compression jobs queued before a source failure must not
+    // fire Node's unhandled-rejection handler while the stream unwinds.
+    const unhandled: unknown[] = [];
+    const listener = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', listener);
+    try {
+      async function* failingSource() {
+        yield Buffer.alloc(3 * 1024 * 1024, 1);
+        yield Buffer.alloc(3 * 1024 * 1024, 2);
+        throw new Error('source blew up');
+      }
+      await expect(gzipStream(failingSource(), { chunkSize: 1024 * 1024 })).rejects.toThrow(
+        'source blew up',
+      );
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', listener);
+    }
+  });
+
+  it('single mode produces one gzip member', async () => {
+    async function* source() {
+      yield Buffer.from('hello world');
+    }
+    const parts = await gzipStream(source(), { strategy: 'single' });
+    const out = Buffer.concat(parts);
+    expect(zlib.gunzipSync(out).toString()).toBe('hello world');
+  });
+});
+
+describe('walk + cpio + bom', () => {
+  let tmp: string;
+  let app: string;
+
+  beforeAll(async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-units-'));
+    app = path.join(tmp, 'parent', 'Unit.app');
+    writeFixtureTree(path.join(tmp, 'parent'), [
+      { path: 'Unit.app/Contents/Info.plist', content: infoPlist('com.example.unit') },
+      { path: 'Unit.app/Contents/MacOS/Fixture', content: '#!/bin/sh\necho hi\n', mode: 0o755 },
+      { path: 'Unit.app/Contents/Resources/data.txt', content: 'hello' },
+      { path: 'Unit.app/Contents/Resources/link', symlink: 'data.txt' },
+      { path: 'Unit.app/Contents/Resources/empty', directory: true },
+    ]);
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('walks with pkgbuild metadata semantics', async () => {
+    const root = await walkTree(app);
+    expect(root.path).toBe('.');
+    expect(root.nlink).toBe(3); // parent dir contains only Unit.app
+    const entries = [...cpioOrder(root)];
+    const byPath = new Map(entries.map((e) => [e.path, e]));
+    expect(byPath.get('./Unit.app/Contents')!.nlink).toBe(5); // 3 children + 2
+    expect(byPath.get('./Unit.app/Contents')!.size).toBe(160);
+    expect(byPath.get('./Unit.app/Contents/Resources/link')!.linkTarget).toBe('data.txt');
+    expect(byPath.get('./Unit.app/Contents/Resources/link')!.size).toBe(8);
+    for (const entry of entries) {
+      expect(entry.uid).toBe(0);
+      expect(entry.gid).toBe(0);
+    }
+  });
+
+  it('bom order sorts children byte-lexicographically', async () => {
+    const root = await walkTree(app);
+    const contents = [...bomOrder(root)]
+      .filter((e) => e.path.startsWith('./Unit.app/Contents/') && e.path.split('/').length === 4)
+      .map((e) => e.name);
+    expect(contents).toEqual(['Info.plist', 'MacOS', 'Resources']);
+  });
+
+  it('writes a parseable cpio stream padded to 512 bytes', async () => {
+    const root = await walkTree(app);
+    const result = newCpioWriteResult();
+    const raw = await collect(cpioStream(root, result));
+    expect(raw.length % 512).toBe(0);
+    const entries = parseCpio(raw);
+    expect(entries[0].name).toBe('.');
+    expect(entries.at(-1)!.name).toBe('TRAILER!!!');
+    // inodes are sequential including the trailer
+    entries.forEach((entry, i) => expect(entry.ino).toBe(i));
+    const file = entries.find((e) => e.name === './Unit.app/Contents/Resources/data.txt')!;
+    expect(file.data.toString()).toBe('hello');
+    expect(file.mtime).toBe(FIXTURE_EPOCH);
+    expect(result.checksums.get('./Unit.app/Contents/Resources/data.txt')).toBe(3287646509);
+    expect(result.checksums.get('./Unit.app/Contents/Resources/link')).toBe(4247533825);
+  });
+
+  it('bom writer output round-trips through the reader', async () => {
+    const root = await walkTree(app);
+    const result = newCpioWriteResult();
+    await collect(cpioStream(root, result));
+    const bom = readBom(writeBom(root, result.checksums));
+    expect(bom.numberOfPaths).toBe(11); // 10 entries + trailer
+    const byPath = new Map(bom.paths.map((p) => [p.path, p]));
+    expect(byPath.get('.')!.mode).toBe(0); // Apple stores 0 for the root
+    expect(byPath.get('./Unit.app/Contents/Resources/data.txt')!.checksum).toBe(3287646509);
+    expect(byPath.get('./Unit.app/Contents/Resources/link')!.linkTarget).toBe('data.txt');
+    expect(byPath.get('./Unit.app/Contents/Resources/link')!.mode & 0o170000).toBe(0o120000);
+    expect(bom.sizeSum).toBe(
+      [...cpioOrder(root)].filter((e) => e.path !== '.').reduce((sum, e) => sum + e.size, 0),
+    );
+    // Tree entries are sorted by (parent id, byte-lexicographic name)
+    for (let i = 1; i < bom.paths.length; i++) {
+      const prev = bom.paths[i - 1];
+      const curr = bom.paths[i];
+      expect(
+        prev.parentId < curr.parentId ||
+          (prev.parentId === curr.parentId &&
+            Buffer.compare(Buffer.from(prev.name), Buffer.from(curr.name)) < 0),
+      ).toBe(true);
+    }
+  });
+
+  it('splits large path sets across multiple bom tree leaves', async () => {
+    const bigTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-units-big-'));
+    const bigApp = path.join(bigTmp, 'parent', 'Big.app');
+    const files = [{ path: 'Big.app/Contents/Info.plist', content: infoPlist('com.example.big') }];
+    for (let i = 0; i < 600; i++) {
+      files.push({
+        path: `Big.app/Contents/Resources/f${String(i).padStart(4, '0')}.txt`,
+        content: `content ${i}`,
+      });
+    }
+    writeFixtureTree(path.join(bigTmp, 'parent'), files);
+    const root = await walkTree(bigApp);
+    const result = newCpioWriteResult();
+    await collect(cpioStream(root, result));
+    const bom = readBom(writeBom(root, result.checksums));
+    expect(bom.paths.length).toBe(605);
+    expect(new Set(bom.paths.map((p) => p.id)).size).toBe(605);
+    fs.rmSync(bigTmp, { recursive: true, force: true });
+  });
+
+  it('packages NFC-named files that native pkgbuild silently drops', async () => {
+    // Regression guard for a deliberate behavioral improvement: Apple's
+    // pkgbuild omits files whose names are NFC-normalized (e.g. "é" as a
+    // single code point) from the payload while still listing them in the
+    // Bom. We package them.
+    const nfcTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-units-nfc-'));
+    const nfcApp = path.join(nfcTmp, 'parent', 'NFC.app');
+    writeFixtureTree(path.join(nfcTmp, 'parent'), [
+      { path: 'NFC.app/Contents/Info.plist', content: infoPlist('com.example.nfc') },
+      { path: 'NFC.app/Contents/Resources/émoji.txt', content: 'included' },
+    ]);
+    const root = await walkTree(nfcApp);
+    const result = newCpioWriteResult();
+    const raw = await collect(cpioStream(root, result));
+    const names = parseCpio(raw).map((e) => e.name);
+    expect(names).toContain('./NFC.app/Contents/Resources/émoji.txt');
+    const bom = readBom(writeBom(root, result.checksums));
+    expect(bom.paths.map((p) => p.name)).toContain('émoji.txt');
+    fs.rmSync(nfcTmp, { recursive: true, force: true });
+  });
+
+  it('rejects unsupported file types', async () => {
+    if (process.platform === 'win32') return;
+    const fifoTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-units-fifo-'));
+    const fifoApp = path.join(fifoTmp, 'parent', 'F.app');
+    writeFixtureTree(path.join(fifoTmp, 'parent'), [
+      { path: 'F.app/Contents/Info.plist', content: infoPlist('com.example.f') },
+    ]);
+    const { execFileSync } = await import('node:child_process');
+    execFileSync('mkfifo', [path.join(fifoApp, 'Contents', 'pipe')]);
+    await expect(walkTree(fifoApp)).rejects.toThrow(/Unsupported file type/);
+    fs.rmSync(fifoTmp, { recursive: true, force: true });
+  });
+});
+
+describe('cpio field limits', () => {
+  function syntheticTree(childCount: number, uid = 0): Parameters<typeof cpioStream>[0] {
+    const children = Array.from({ length: childCount }, (_, i) => ({
+      path: `./d${i}`,
+      name: `d${i}`,
+      type: 'directory' as const,
+      mode: 0o040755,
+      uid,
+      gid: 0,
+      mtime: FIXTURE_EPOCH,
+      size: 64,
+      nlink: 2,
+      sourcePath: '',
+      children: [],
+    }));
+    return {
+      path: '.',
+      name: '.',
+      type: 'directory',
+      mode: 0o040755,
+      uid,
+      gid: 0,
+      mtime: FIXTURE_EPOCH,
+      size: 32 * (childCount + 2),
+      nlink: childCount + 2,
+      sourcePath: '',
+      children,
+    };
+  }
+
+  it('wraps the synthetic inode counter past 262,143 instead of failing', async () => {
+    // Regression: the 6-digit octal ino field overflows at 0o1000000 entries;
+    // packaging must keep going (the inode is meaningless to Installer).
+    const root = syntheticTree(0o1000000 + 5);
+    const result = newCpioWriteResult();
+    let count = 0;
+    let sawWrapped = false;
+    for await (const buf of cpioStream(root, result)) {
+      if (count === 0) {
+        // First buffer is the root header.
+        expect(buf.subarray(12, 18).toString()).toBe('000000');
+      }
+      if (buf.length === 76 && buf.subarray(0, 6).toString() === '070707') {
+        const ino = parseInt(buf.subarray(12, 18).toString(), 8);
+        expect(ino).toBeLessThanOrEqual(0o777777);
+        if (count > 0o777777) sawWrapped = true;
+      }
+      count++;
+    }
+    expect(sawWrapped).toBe(true);
+  }, 60_000);
+
+  it('clamps uids that do not fit the 6-digit octal field to root', async () => {
+    // Regression: LDAP/AD accounts commonly have uids > 262,143; a scripts
+    // directory owned by one must not abort packaging.
+    const root = syntheticTree(1, 1128796696);
+    const result = newCpioWriteResult();
+    const parts: Buffer[] = [];
+    for await (const buf of cpioStream(root, result)) parts.push(buf);
+    const entries = parseCpio(Buffer.concat(parts));
+    expect(entries[0].uid).toBe(0);
+    expect(entries[1].uid).toBe(0);
+  });
+});
+
+describe('xar', () => {
+  it('rejects cleanly when the output path cannot be written', async () => {
+    // Regression: stream 'error' events must reject writeXar, not crash the
+    // process with an uncaught exception.
+    await expect(
+      writeXar('/nonexistent-dir-for-sure/out.xar', [{ name: 'f', parts: [Buffer.from('x')] }]),
+    ).rejects.toThrow();
+  });
+
+  it('round-trips files and directories', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-units-xar-'));
+    const out = path.join(tmp, 'test.xar');
+    const payload = Buffer.from('payload data'.repeat(100));
+    await writeXar(out, [
+      {
+        name: 'com.example & test.pkg',
+        children: [
+          { name: 'Bom', parts: [Buffer.from('bom-bytes')], compress: true },
+          { name: 'Payload', parts: [payload.subarray(0, 500), payload.subarray(500)] },
+        ],
+      },
+      { name: 'Distribution', parts: [Buffer.from('<installer-gui-script/>')], compress: true },
+    ]);
+    const members = await readXar(out);
+    const paths = members.map((m) => m.path);
+    expect(paths).toEqual([
+      'com.example & test.pkg',
+      'com.example & test.pkg/Bom',
+      'com.example & test.pkg/Payload',
+      'Distribution',
+    ]);
+    expect(members[1].data!.toString()).toBe('bom-bytes');
+    expect(Buffer.compare(members[2].data!, payload)).toBe(0);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});
+
+describe('percentEncodeFragment', () => {
+  it('matches productbuild fragment encoding (verified against native output)', () => {
+    // Every expected value below was produced by the real productbuild.
+    expect(percentEncodeFragment('My App-component.pkg')).toBe('My%20App-component.pkg');
+    expect(percentEncodeFragment("Wéird & 'q' +p.pkg")).toBe("We%CC%81ird%20&%20'q'%20+p.pkg");
+    expect(percentEncodeFragment('pct%25.pkg')).toBe('pct%2525.pkg');
+    expect(percentEncodeFragment('hash#f.pkg')).toBe('hash%23f.pkg');
+    expect(percentEncodeFragment('q?ue.pkg')).toBe('q?ue.pkg');
+    expect(percentEncodeFragment('com.example.app.pkg')).toBe('com.example.app.pkg');
+  });
+
+  it('is applied to the trailing pkg-ref', () => {
+    const xml = renderDistribution({
+      identifier: 'com.example.app',
+      version: '1.0.0',
+      installLocation: '/Applications',
+      installKBytes: 1,
+      packageRef: 'My App-component.pkg',
+      hostArchitectures: 'arm64',
+      bundle: { path: 'My App.app', identifier: 'com.example.app' },
+      productStyle: false,
+    });
+    expect(xml).toContain('>#My%20App-component.pkg</pkg-ref>');
+  });
+});
+
+describe('scripts registration', () => {
+  it('registers symlinked preinstall/postinstall scripts like pkgbuild does', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-units-symscripts-'));
+    const app = path.join(tmp, 'parent', 'Sym.app');
+    writeFixtureTree(path.join(tmp, 'parent'), [
+      { path: 'Sym.app/Contents/Info.plist', content: infoPlist('com.example.sym') },
+    ]);
+    const scripts = path.join(tmp, 'scripts');
+    writeFixtureTree(scripts, [
+      { path: 'real/actual.sh', content: '#!/bin/sh\nexit 0\n', mode: 0o755 },
+      { path: 'preinstall', content: '#!/bin/sh\nexit 0\n', mode: 0o755 },
+      { path: 'postinstall', symlink: 'real/actual.sh' },
+    ]);
+    const component = await buildComponentPackage({ app, scripts });
+    const packageInfo = component.packageInfo.toString('utf8');
+    expect(packageInfo).toContain('<preinstall file="./preinstall" timeout="600"/>');
+    expect(packageInfo).toContain('<postinstall file="./postinstall" timeout="600"/>');
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});
+
+describe('document rendering', () => {
+  it('renders PackageInfo in pkgbuild shape', () => {
+    const xml = renderPackageInfo({
+      identifier: 'com.example.app',
+      version: '1.2.3',
+      installLocation: '/Applications',
+      numberOfFiles: 8,
+      installKBytes: 42,
+      bundle: {
+        path: 'App.app',
+        identifier: 'com.example.app',
+        shortVersionString: '1.2.3',
+        bundleVersion: '123',
+      },
+    });
+    expect(xml).toContain('<payload numberOfFiles="8" installKBytes="42"/>');
+    expect(xml).toContain(
+      '<bundle path="./App.app" id="com.example.app" CFBundleShortVersionString="1.2.3" CFBundleVersion="123"/>',
+    );
+    expect(xml.endsWith('</pkg-info>')).toBe(true);
+    expect(parseXml(xml).name).toBe('pkg-info');
+  });
+
+  it('escapes XML-significant characters from bundle metadata', () => {
+    const xml = renderDistribution({
+      identifier: 'com.example."quoted"&<app>',
+      version: '1.0.0',
+      installLocation: '/Applications',
+      installKBytes: 1,
+      packageRef: 'x.pkg',
+      hostArchitectures: 'arm64',
+      bundle: { path: 'App.app', identifier: 'com.example.app' },
+      productStyle: true,
+      title: 'Title & <Friends>',
+    });
+    expect(xml).toContain('<title>Title &amp; &lt;Friends&gt;</title>');
+    expect(parseXml(xml).name).toBe('installer-gui-script');
+  });
+});
+
+describe('buildComponentPackage', () => {
+  it('builds deterministic metadata from a fixture app', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-units-bcp-'));
+    const app = path.join(tmp, 'parent', 'Meta.app');
+    writeFixtureTree(path.join(tmp, 'parent'), [
+      {
+        path: 'Meta.app/Contents/Info.plist',
+        content: infoPlist('com.example.meta', {
+          CFBundleName: 'Meta',
+          CFBundleShortVersionString: '2.1',
+          CFBundleVersion: '77',
+        }),
+      },
+      { path: 'Meta.app/Contents/Resources/blob.bin', content: Buffer.alloc(4000, 7) },
+    ]);
+    const component = await buildComponentPackage({ app });
+    expect(component.identifier).toBe('com.example.meta');
+    expect(component.version).toBe('2.1.0');
+    expect(component.title).toBe('Meta');
+    expect(component.numberOfFiles).toBe(5);
+    // sizeSum: plist + blob + dirs (Meta.app 96, Contents 128, Resources 64+32)
+    const plistSize = fs.statSync(path.join(app, 'Contents', 'Info.plist')).size;
+    expect(component.installKBytes).toBe(Math.floor((plistSize + 4000 + 96 + 128 + 96) / 1024));
+    expect(zlib.gunzipSync(Buffer.concat(component.payload)).length % 512).toBe(0);
+    expect(component.packageInfo.toString()).toContain('identifier="com.example.meta"');
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});

--- a/spec/pkg-utils/pkg-units.spec.ts
+++ b/spec/pkg-utils/pkg-units.spec.ts
@@ -176,11 +176,11 @@ describe('gzip', () => {
     }
   });
 
-  it('single mode produces one gzip member', async () => {
+  it('handles inputs smaller than one chunk', async () => {
     async function* source() {
       yield Buffer.from('hello world');
     }
-    const parts = await gzipStream(source(), { strategy: 'single' });
+    const parts = await gzipStream(source());
     const out = Buffer.concat(parts);
     expect(zlib.gunzipSync(out).toString()).toBe('hello world');
   });

--- a/src/flat.ts
+++ b/src/flat.ts
@@ -13,6 +13,7 @@ import { Identity, findIdentities } from './util-identities.js';
 import type { FlatOptions, ValidatedFlatOptions } from './types.js';
 import { modifyPayloadPermissions } from './pkg-utils/cpio.js';
 import { setPermissionOnBom } from './pkg-utils/bom.js';
+import { buildProductArchive } from './pkg-utils/pkg.js';
 
 /**
  * This function returns a promise validating all options passed in opts.
@@ -49,6 +50,16 @@ async function validateFlatOpts(opts: FlatOptions): Promise<ValidatedFlatOptions
     debugWarn('Mac App Store packages cannot have `scripts`, ignoring option.');
   }
 
+  if (
+    opts.implementation !== undefined &&
+    opts.implementation !== 'native' &&
+    opts.implementation !== 'js'
+  ) {
+    throw new Error(
+      `\`implementation\` must be either \`native\` or \`js\`, got \`${String(opts.implementation)}\``,
+    );
+  }
+
   return {
     ...opts,
     pkg,
@@ -58,10 +69,69 @@ async function validateFlatOpts(opts: FlatOptions): Promise<ValidatedFlatOptions
 }
 
 /**
+ * Squirrel.Mac-friendly permissions: files and directories installed as
+ * root:admin with group-writable modes so any admin can update the app.
+ * Mirrors what {@link setPermissionOnBom} does to native pkgbuild output.
+ */
+function openPermissionsTransform(entry: { path: string; mode: number }): {
+  mode?: number;
+  gid: number;
+} {
+  // The payload root is always forced to 0775, matching the unconditional
+  // root rewrite in setPermissionOnBom.
+  if (entry.path === '.') return { mode: 0o775, gid: 80 };
+  const perms = entry.mode & 0o777;
+  const special = entry.mode & 0o7000;
+  let mode: number | undefined;
+  if (perms === 0o755) mode = special | 0o775;
+  else if (perms === 0o644) mode = special | 0o664;
+  return { mode, gid: 80 };
+}
+
+/**
+ * Build the flat package with the pure-JS implementation, then sign it with
+ * `productsign` when an identity was resolved.
+ */
+async function buildApplicationPkgJS(opts: ValidatedFlatOptions, identity: Identity | null) {
+  const unsignedPkg = identity ? `${opts.pkg}.unsigned` : opts.pkg;
+  debugLog('Flattening package with the JS implementation... ' + opts.app);
+  try {
+    await buildProductArchive({
+      app: opts.app,
+      installLocation: opts.install,
+      output: unsignedPkg,
+      // MAS packages go through `productbuild --component`; everything else
+      // historically used `pkgbuild` + `productbuild --package` (which is
+      // also the only shape that supports scripts).
+      componentStyle: opts.platform === 'mas',
+      scripts: opts.platform === 'mas' ? undefined : opts.scripts,
+      transformEntry: opts.openPermissionsForSquirrelMac ? openPermissionsTransform : undefined,
+    });
+
+    if (identity) {
+      debugLog('Signing package with productsign...', opts.pkg);
+      // productsign refuses to overwrite an existing destination, unlike
+      // `productbuild --sign` which the native path uses.
+      await fs.promises.rm(opts.pkg, { force: true });
+      const args = ['--sign', identity.name];
+      if (opts.keychain) args.unshift('--keychain', opts.keychain);
+      await execFileAsync('productsign', [...args, unsignedPkg, opts.pkg]);
+    }
+  } finally {
+    if (unsignedPkg !== opts.pkg) {
+      await fs.promises.rm(unsignedPkg, { force: true });
+    }
+  }
+}
+
+/**
  * This function returns a promise flattening the application.
  * @param opts - Options for building the .pkg archive
  */
 async function buildApplicationPkg(opts: ValidatedFlatOptions, identity: Identity | null) {
+  if (opts.implementation === 'js') {
+    return buildApplicationPkgJS(opts, identity);
+  }
   if (opts.platform === 'mas') {
     const signArgs = identity ? ['--sign', identity.name] : [];
     const args = ['--component', opts.app, opts.install, ...signArgs, opts.pkg];

--- a/src/pkg-utils/bom-reader.ts
+++ b/src/pkg-utils/bom-reader.ts
@@ -1,0 +1,163 @@
+/**
+ * Minimal reader for Apple's BOMStore format — enough to reconstruct the
+ * information lsbom prints, used by the test-suite to verify parity between
+ * our Bom writer and Apple's mkbom/pkgbuild.
+ */
+
+export interface BomPath {
+  id: number;
+  parentId: number;
+  name: string;
+  path: string;
+  type: 'file' | 'directory' | 'symlink' | 'device';
+  architecture: number;
+  mode: number;
+  uid: number;
+  gid: number;
+  mtime: number;
+  size: number;
+  checksum: number;
+  linkTarget?: string;
+}
+
+export interface BomFile {
+  numberOfPaths: number;
+  sizeSum: number;
+  /** Paths in tree (leaf traversal) order. */
+  paths: BomPath[];
+}
+
+const TYPE_NAMES: Record<number, BomPath['type']> = {
+  1: 'file',
+  2: 'directory',
+  3: 'symlink',
+  4: 'device',
+};
+
+export function readBom(data: Buffer): BomFile {
+  if (data.toString('ascii', 0, 8) !== 'BOMStore') {
+    throw new Error('Not a BOMStore file');
+  }
+  const indexOffset = data.readUInt32BE(16);
+  const varsOffset = data.readUInt32BE(24);
+
+  const blockCount = data.readUInt32BE(indexOffset);
+  const blockAt = (id: number): Buffer => {
+    if (id < 0 || id >= blockCount) throw new Error(`Bom block ${id} out of range`);
+    const addr = data.readUInt32BE(indexOffset + 4 + id * 8);
+    const len = data.readUInt32BE(indexOffset + 8 + id * 8);
+    return data.subarray(addr, addr + len);
+  };
+
+  const vars = new Map<string, number>();
+  let pos = varsOffset;
+  const varCount = data.readUInt32BE(pos);
+  pos += 4;
+  for (let i = 0; i < varCount; i++) {
+    const blockId = data.readUInt32BE(pos);
+    pos += 4;
+    const nameLen = data.readUInt8(pos);
+    pos += 1;
+    const name = data.toString('ascii', pos, pos + nameLen);
+    pos += nameLen;
+    vars.set(name, blockId);
+  }
+
+  const bomInfoId = vars.get('BomInfo');
+  const pathsId = vars.get('Paths');
+  if (bomInfoId === undefined || pathsId === undefined) {
+    throw new Error('Bom is missing BomInfo/Paths variables');
+  }
+  const bomInfo = blockAt(bomInfoId);
+  const numberOfPaths = bomInfo.readUInt32BE(4);
+  const infoEntries = bomInfo.readUInt32BE(8);
+  const sizeSum = infoEntries > 0 ? bomInfo.readUInt32BE(20) : 0;
+
+  const tree = blockAt(pathsId);
+  if (tree.toString('ascii', 0, 4) !== 'tree') {
+    throw new Error('Bom Paths variable is not a tree');
+  }
+  const rootNodeId = tree.readUInt32BE(8);
+
+  // Find the leftmost leaf, then follow forward pointers.
+  let node = blockAt(rootNodeId);
+  while (node.readUInt16BE(0) === 0) {
+    const count = node.readUInt16BE(2);
+    if (count === 0) break;
+    node = blockAt(node.readUInt32BE(12));
+  }
+
+  const paths: BomPath[] = [];
+  const nameById = new Map<number, { parentId: number; name: string }>();
+  for (;;) {
+    const count = node.readUInt16BE(2);
+    const forward = node.readUInt32BE(4);
+    for (let i = 0; i < count; i++) {
+      const valueId = node.readUInt32BE(12 + i * 8);
+      const keyId = node.readUInt32BE(16 + i * 8);
+      const key = blockAt(keyId);
+      const parentId = key.readUInt32BE(0);
+      let nameEnd = 4;
+      while (nameEnd < key.length && key[nameEnd] !== 0) nameEnd++;
+      const name = key.toString('utf8', 4, nameEnd);
+      const value = blockAt(valueId);
+      const id = value.readUInt32BE(0);
+      const info = blockAt(value.readUInt32BE(4));
+      const type = TYPE_NAMES[info.readUInt8(0)];
+      if (!type) throw new Error(`Unknown Bom path type ${info.readUInt8(0)} for ${name}`);
+      const linkNameLength = info.readUInt32BE(27);
+      const record: BomPath = {
+        id,
+        parentId,
+        name,
+        path: '',
+        type,
+        architecture: info.readUInt16BE(2),
+        mode: info.readUInt16BE(4),
+        uid: info.readUInt32BE(6),
+        gid: info.readUInt32BE(10),
+        mtime: info.readUInt32BE(14),
+        size: info.readUInt32BE(18),
+        checksum: info.readUInt32BE(23),
+      };
+      if (linkNameLength > 0) {
+        record.linkTarget = info.toString('utf8', 31, 31 + linkNameLength - 1);
+      }
+      nameById.set(id, { parentId, name });
+      paths.push(record);
+    }
+    if (!forward) break;
+    node = blockAt(forward);
+  }
+
+  for (const record of paths) {
+    const segments: string[] = [];
+    let cursor: { parentId: number; name: string } | undefined = {
+      parentId: record.parentId,
+      name: record.name,
+    };
+    while (cursor) {
+      segments.unshift(cursor.name);
+      cursor = cursor.parentId === 0 ? undefined : nameById.get(cursor.parentId);
+    }
+    record.path = segments.join('/');
+  }
+
+  return { numberOfPaths, sizeSum, paths };
+}
+
+/**
+ * Render the same text lsbom prints by default (tab-separated path, mode,
+ * uid/gid, size, checksum, link target), sorted by path like lsbom output.
+ */
+export function lsbomLines(bom: BomFile): string[] {
+  const lines = bom.paths.map((p) => {
+    const fields = [p.path, p.mode.toString(8), `${p.uid}/${p.gid}`];
+    if (p.type === 'file' || p.type === 'symlink') {
+      fields.push(String(p.size), String(p.checksum));
+      if (p.linkTarget !== undefined) fields.push(p.linkTarget);
+    }
+    return fields.join('\t');
+  });
+  return lines.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}

--- a/src/pkg-utils/bom-writer.ts
+++ b/src/pkg-utils/bom-writer.ts
@@ -1,0 +1,347 @@
+import { WalkEntry, bomNameCompare, bomOrder } from './walk.js';
+
+/**
+ * Writer for Apple's Bill-of-Materials (BOMStore) binary format, as produced
+ * by mkbom/pkgbuild and consumed by Installer, lsbom and ditto.
+ *
+ * Layout: a 512-byte header, a heap of variable-size blocks, a block index
+ * table (u32 count, then {u32 address, u32 length} per block; block 0 is the
+ * null block), and a variables area naming the top-level blocks (BomInfo,
+ * Paths, HLIndex, VIndex, Size64).
+ *
+ * The Paths variable is a B+tree ("tree" block) keyed by (parent id, name)
+ * whose leaves point at BOMPathInfo1 {id, info2 block} / BOMFile
+ * {parent id, NUL-terminated name} pairs. Ids are assigned depth-first with
+ * children in byte-lexicographic order, matching Apple's tools.
+ */
+
+const HEADER_SIZE = 512;
+const TREE_BLOCK_SIZE = 4096;
+const TREE_ENTRIES_PER_LEAF = 256;
+const PATH_TYPE: Record<WalkEntry['type'], number> = {
+  file: 1,
+  directory: 2,
+  symlink: 3,
+};
+
+interface BomEntryRecord {
+  id: number;
+  parentId: number;
+  name: string;
+  entry: WalkEntry;
+}
+
+class BlockStore {
+  /** Block 0 is the null block. */
+  private blocks: Buffer[] = [Buffer.alloc(0)];
+
+  add(buf: Buffer): number {
+    this.blocks.push(buf);
+    return this.blocks.length - 1;
+  }
+
+  /** Reserve an id whose contents are provided later. */
+  reserve(): number {
+    this.blocks.push(Buffer.alloc(0));
+    return this.blocks.length - 1;
+  }
+
+  set(id: number, buf: Buffer): void {
+    this.blocks[id] = buf;
+  }
+
+  assemble(vars: { name: string; blockId: number }[]): Buffer {
+    // Header | blocks | index | vars
+    let offset = HEADER_SIZE;
+    const addresses: number[] = Array.from({ length: this.blocks.length }, () => 0);
+    for (let i = 0; i < this.blocks.length; i++) {
+      addresses[i] = this.blocks[i].length === 0 ? 0 : offset;
+      offset += this.blocks[i].length;
+    }
+    const indexOffset = offset;
+    // The pointer table is followed by a free-space list that BOMStore always
+    // parses: an entry count plus zero-terminated {address, length} pairs. We
+    // never leave holes, so it is empty (count 0 + terminator pair).
+    const freeListLength = 12;
+    const indexLength = 4 + this.blocks.length * 8 + freeListLength;
+    offset += indexLength;
+    const varsOffset = offset;
+    let varsLength = 4;
+    for (const v of vars) varsLength += 5 + Buffer.byteLength(v.name);
+
+    const total = varsOffset + varsLength;
+    const out = Buffer.alloc(total);
+
+    out.write('BOMStore', 0, 'ascii');
+    out.writeUInt32BE(1, 8); // version
+    out.writeUInt32BE(this.blocks.length - 1, 12); // number of non-null blocks
+    out.writeUInt32BE(indexOffset, 16);
+    out.writeUInt32BE(indexLength, 20);
+    out.writeUInt32BE(varsOffset, 24);
+    out.writeUInt32BE(varsLength, 28);
+
+    let pos = HEADER_SIZE;
+    for (let i = 0; i < this.blocks.length; i++) {
+      this.blocks[i].copy(out, pos);
+      pos += this.blocks[i].length;
+    }
+
+    out.writeUInt32BE(this.blocks.length, pos);
+    pos += 4;
+    for (let i = 0; i < this.blocks.length; i++) {
+      out.writeUInt32BE(addresses[i], pos);
+      out.writeUInt32BE(this.blocks[i].length, pos + 4);
+      pos += 8;
+    }
+    pos += freeListLength; // empty free list: all zeroes
+
+    out.writeUInt32BE(vars.length, pos);
+    pos += 4;
+    for (const v of vars) {
+      out.writeUInt32BE(v.blockId, pos);
+      pos += 4;
+      out.writeUInt8(Buffer.byteLength(v.name), pos);
+      pos += 1;
+      out.write(v.name, pos, 'ascii');
+      pos += Buffer.byteLength(v.name);
+    }
+
+    return out;
+  }
+}
+
+function pathInfo2(entry: WalkEntry, checksum: number): Buffer {
+  const isRoot = entry.path === '.';
+  const linkTarget = entry.type === 'symlink' ? Buffer.from(entry.linkTarget ?? '', 'utf8') : null;
+  // Apple appends per-type trailing reserved zero bytes: 4 for regular files,
+  // 8 for symlinks, none for directories.
+  const trailing = entry.type === 'file' ? 4 : entry.type === 'symlink' ? 8 : 0;
+  const linkNameLength = linkTarget ? linkTarget.length + 1 : 0;
+  // Base record is 31 bytes: type, unknown, architecture, mode, user, group,
+  // modtime, size, unknown, checksum, linkNameLength.
+  const buf = Buffer.alloc(31 + linkNameLength + trailing);
+  buf.writeUInt8(PATH_TYPE[entry.type], 0);
+  buf.writeUInt8(1, 1); // unknown, always 1
+  buf.writeUInt16BE(isRoot ? 0x01 : 0x0f, 2); // "architecture"
+  buf.writeUInt16BE(isRoot ? 0 : entry.mode & 0xffff, 4);
+  buf.writeUInt32BE(entry.uid, 6);
+  buf.writeUInt32BE(entry.gid, 10);
+  buf.writeUInt32BE(isRoot ? 0 : entry.mtime, 14);
+  buf.writeUInt32BE(isRoot ? 0 : entry.size >>> 0, 18);
+  buf.writeUInt8(1, 22); // unknown, always 1
+  buf.writeUInt32BE(isRoot ? 0 : checksum >>> 0, 23);
+  buf.writeUInt32BE(linkNameLength, 27);
+  if (linkTarget) {
+    linkTarget.copy(buf, 31);
+    // NUL terminator is already zero from Buffer.alloc
+  }
+  return buf;
+}
+
+function emptyTree(store: BlockStore, blockSize: number): number {
+  const leaf = Buffer.alloc(blockSize);
+  leaf.writeUInt16BE(1, 0); // isLeaf
+  const leafId = store.add(leaf);
+  const tree = Buffer.alloc(21);
+  tree.write('tree', 0, 'ascii');
+  tree.writeUInt32BE(1, 4); // version
+  tree.writeUInt32BE(leafId, 8);
+  tree.writeUInt32BE(blockSize, 12);
+  tree.writeUInt32BE(0, 16); // path count
+  return store.add(tree);
+}
+
+/**
+ * Build a B+tree from ordered (value, key) block-id pairs. Returns the block
+ * id of the root node. Interior entries carry the last key of each child,
+ * mirroring Apple's mkbom.
+ */
+function buildTree(store: BlockStore, pairs: { value: number; key: number }[]): number {
+  if (pairs.length === 0) {
+    const leaf = Buffer.alloc(TREE_BLOCK_SIZE);
+    leaf.writeUInt16BE(1, 0);
+    return store.add(leaf);
+  }
+
+  // Split into leaves.
+  const leafChunks: { value: number; key: number }[][] = [];
+  for (let i = 0; i < pairs.length; i += TREE_ENTRIES_PER_LEAF) {
+    leafChunks.push(pairs.slice(i, i + TREE_ENTRIES_PER_LEAF));
+  }
+  const leafIds = leafChunks.map(() => store.reserve());
+  leafChunks.forEach((chunk, i) => {
+    const buf = Buffer.alloc(TREE_BLOCK_SIZE);
+    buf.writeUInt16BE(1, 0);
+    buf.writeUInt16BE(chunk.length, 2);
+    buf.writeUInt32BE(i + 1 < leafIds.length ? leafIds[i + 1] : 0, 4); // forward
+    buf.writeUInt32BE(i > 0 ? leafIds[i - 1] : 0, 8); // backward
+    let pos = 12;
+    for (const pair of chunk) {
+      buf.writeUInt32BE(pair.value, pos);
+      buf.writeUInt32BE(pair.key, pos + 4);
+      pos += 8;
+    }
+    store.set(leafIds[i], buf);
+  });
+
+  // Build interior levels until a single node remains.
+  let level: { nodeId: number; lastKey: number }[] = leafChunks.map((chunk, i) => ({
+    nodeId: leafIds[i],
+    lastKey: chunk[chunk.length - 1].key,
+  }));
+  while (level.length > 1) {
+    const next: { nodeId: number; lastKey: number }[] = [];
+    for (let i = 0; i < level.length; i += TREE_ENTRIES_PER_LEAF) {
+      const group = level.slice(i, i + TREE_ENTRIES_PER_LEAF);
+      const buf = Buffer.alloc(TREE_BLOCK_SIZE);
+      buf.writeUInt16BE(0, 0); // interior
+      buf.writeUInt16BE(group.length, 2);
+      let pos = 12;
+      for (const child of group) {
+        buf.writeUInt32BE(child.nodeId, pos);
+        buf.writeUInt32BE(child.lastKey, pos + 4);
+        pos += 8;
+      }
+      next.push({ nodeId: store.add(buf), lastKey: group[group.length - 1].lastKey });
+    }
+    level = next;
+  }
+  return level[0].nodeId;
+}
+
+/**
+ * Generate a Bom for a walked tree. `checksums` maps entry path to the CRC32
+ * of the file contents (or symlink target), as computed while writing the
+ * payload.
+ */
+export interface BomArchInfo {
+  /** Summed Mach-O slice sizes per cpu type. */
+  archSizes: Map<number, number>;
+  /** Total bytes of files identified as Mach-O (excluded from the cpu-type-0 sum). */
+  machOFileBytes: number;
+}
+
+export function writeBom(
+  root: WalkEntry,
+  checksums: Map<string, number>,
+  archInfo?: BomArchInfo,
+): Buffer {
+  const store = new BlockStore();
+
+  // Assign ids depth-first with byte-lexicographically sorted children.
+  const records: BomEntryRecord[] = [];
+  const idByPath = new Map<string, number>();
+  let nextId = 1;
+  for (const entry of bomOrder(root)) {
+    const id = nextId++;
+    idByPath.set(entry.path, id);
+    const parentPath = entry.path === '.' ? null : entry.path.slice(0, entry.path.lastIndexOf('/'));
+    const parentId =
+      parentPath === null ? 0 : (idByPath.get(parentPath === '' ? '.' : parentPath) ?? 0);
+    records.push({ id, parentId, name: entry.name, entry });
+  }
+
+  // Tree entries sorted by (parent id, decomposed-byte-lexicographic name).
+  const sorted = [...records].sort((a, b) => {
+    if (a.parentId !== b.parentId) return a.parentId - b.parentId;
+    return bomNameCompare(a.name, b.name);
+  });
+
+  // BomInfo: version, path count (+1 for the archive trailer), then one size
+  // entry per cpu type. Entry 0 sums every non-Mach-O byte; Mach-O files
+  // contribute their slice sizes to their cpu types instead.
+  let sizeSum = 0;
+  for (const record of records) {
+    if (record.entry.path !== '.') sizeSum += record.entry.size;
+  }
+  const archEntries: { cpuType: number; size: number }[] = [
+    { cpuType: 0, size: sizeSum - (archInfo?.machOFileBytes ?? 0) },
+  ];
+  if (archInfo) {
+    for (const cpuType of [...archInfo.archSizes.keys()].sort((a, b) => a - b)) {
+      archEntries.push({ cpuType, size: archInfo.archSizes.get(cpuType)! });
+    }
+  }
+  const bomInfo = Buffer.alloc(12 + archEntries.length * 16);
+  bomInfo.writeUInt32BE(1, 0);
+  bomInfo.writeUInt32BE(records.length + 1, 4);
+  bomInfo.writeUInt32BE(archEntries.length, 8);
+  archEntries.forEach((entry, i) => {
+    bomInfo.writeUInt32BE(entry.cpuType >>> 0, 12 + i * 16);
+    bomInfo.writeUInt32BE(entry.size >>> 0, 20 + i * 16);
+  });
+  const bomInfoId = store.add(bomInfo);
+
+  const info2Ids: number[] = [];
+  const pairs = sorted.map((record) => {
+    const info2Id = store.add(pathInfo2(record.entry, checksums.get(record.entry.path) ?? 0));
+    info2Ids.push(info2Id);
+    const info1 = Buffer.alloc(8);
+    info1.writeUInt32BE(record.id, 0);
+    info1.writeUInt32BE(info2Id, 4);
+    const value = store.add(info1);
+    const nameBuf = Buffer.from(record.name, 'utf8');
+    const file = Buffer.alloc(4 + nameBuf.length + 1);
+    file.writeUInt32BE(record.parentId, 0);
+    nameBuf.copy(file, 4);
+    const key = store.add(file);
+    return { value, key };
+  });
+
+  const pathsRootId = buildTree(store, pairs);
+  const pathsTree = Buffer.alloc(21);
+  pathsTree.write('tree', 0, 'ascii');
+  pathsTree.writeUInt32BE(1, 4);
+  pathsTree.writeUInt32BE(pathsRootId, 8);
+  pathsTree.writeUInt32BE(TREE_BLOCK_SIZE, 12);
+  pathsTree.writeUInt32BE(records.length, 16);
+  const pathsId = store.add(pathsTree);
+
+  // HLIndex: hardlink index. Every path gets an entry mapping a pointer to
+  // its BOMPathInfo2 block to a (here always empty) subtree of hardlinked
+  // paths, keyed in ascending info2 block order — exactly what mkbom emits
+  // for a tree without hardlinks.
+  const hlPairs = info2Ids.map((info2Id) => {
+    const subLeaf = Buffer.alloc(64);
+    subLeaf.writeUInt16BE(1, 0);
+    const subLeafId = store.add(subLeaf);
+    const subTree = Buffer.alloc(21);
+    subTree.write('tree', 0, 'ascii');
+    subTree.writeUInt32BE(1, 4);
+    subTree.writeUInt32BE(subLeafId, 8);
+    subTree.writeUInt32BE(64, 12);
+    const subTreeId = store.add(subTree);
+    const keyPtr = Buffer.alloc(4);
+    keyPtr.writeUInt32BE(info2Id, 0);
+    const valuePtr = Buffer.alloc(4);
+    valuePtr.writeUInt32BE(subTreeId, 0);
+    return { value: store.add(valuePtr), key: store.add(keyPtr) };
+  });
+  const hlRootId = buildTree(store, hlPairs);
+  const hlTree = Buffer.alloc(21);
+  hlTree.write('tree', 0, 'ascii');
+  hlTree.writeUInt32BE(1, 4);
+  hlTree.writeUInt32BE(hlRootId, 8);
+  hlTree.writeUInt32BE(TREE_BLOCK_SIZE, 12);
+  hlTree.writeUInt32BE(records.length, 16);
+  const hlIndexId = store.add(hlTree);
+
+  // VIndex: an indirection struct pointing at an empty tree with 128-byte blocks.
+  const vTreeId = emptyTree(store, 128);
+  const vIndex = Buffer.alloc(13);
+  vIndex.writeUInt32BE(1, 0);
+  vIndex.writeUInt32BE(vTreeId, 4);
+  const vIndexId = store.add(vIndex);
+
+  // Size64: tree of 64-bit sizes for files over 4 GB. Empty; files that large
+  // are rejected upstream to match the 32-bit fields used elsewhere.
+  const size64Id = emptyTree(store, TREE_BLOCK_SIZE);
+
+  return store.assemble([
+    { name: 'BomInfo', blockId: bomInfoId },
+    { name: 'Paths', blockId: pathsId },
+    { name: 'HLIndex', blockId: hlIndexId },
+    { name: 'VIndex', blockId: vIndexId },
+    { name: 'Size64', blockId: size64Id },
+  ]);
+}

--- a/src/pkg-utils/cksum.ts
+++ b/src/pkg-utils/cksum.ts
@@ -1,0 +1,39 @@
+/**
+ * POSIX cksum CRC (CRC-32/CKSUM): polynomial 0x04C11DB7, MSB-first, zero
+ * initial value, message length appended least-significant-octet first, final
+ * complement. This is the checksum Apple's mkbom records for Bom entries.
+ */
+
+const TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let crc = i << 24;
+    for (let j = 0; j < 8; j++) {
+      crc = crc & 0x80000000 ? ((crc << 1) ^ 0x04c11db7) >>> 0 : (crc << 1) >>> 0;
+    }
+    table[i] = crc >>> 0;
+  }
+  return table;
+})();
+
+export function cksumUpdate(crc: number, data: Buffer): number {
+  let value = crc >>> 0;
+  for (let i = 0; i < data.length; i++) {
+    value = (((value << 8) >>> 0) ^ TABLE[((value >>> 24) ^ data[i]) & 0xff]) >>> 0;
+  }
+  return value;
+}
+
+export function cksumFinalize(crc: number, length: number): number {
+  let value = crc >>> 0;
+  let remaining = length;
+  while (remaining > 0) {
+    value = (((value << 8) >>> 0) ^ TABLE[((value >>> 24) ^ (remaining & 0xff)) & 0xff]) >>> 0;
+    remaining = Math.floor(remaining / 256);
+  }
+  return ~value >>> 0;
+}
+
+export function cksum(data: Buffer): number {
+  return cksumFinalize(cksumUpdate(0, data), data.length);
+}

--- a/src/pkg-utils/cpio-writer.ts
+++ b/src/pkg-utils/cpio-writer.ts
@@ -1,0 +1,181 @@
+import fs from 'node:fs';
+
+import { WalkEntry, cpioOrder } from './walk.js';
+import { cksum, cksumFinalize, cksumUpdate } from './cksum.js';
+import { machOSliceSizes } from './macho.js';
+
+const MAGIC = '070707';
+const TRAILER_NAME = 'TRAILER!!!';
+const BLOCK_SIZE = 512;
+/** Read large files in slices so peak memory stays bounded. */
+const FILE_READ_CHUNK = 8 * 1024 * 1024;
+
+function octal(value: number, width: number): string {
+  const str = (value >>> 0).toString(8);
+  if (str.length > width) {
+    throw new Error(`cpio field overflow: ${value} does not fit in ${width} octal digits`);
+  }
+  return str.padStart(width, '0');
+}
+
+function header(fields: {
+  dev: number;
+  ino: number;
+  mode: number;
+  uid: number;
+  gid: number;
+  nlink: number;
+  rdev: number;
+  mtime: number;
+  namesize: number;
+  filesize: number;
+}): Buffer {
+  const str =
+    MAGIC +
+    octal(fields.dev, 6) +
+    octal(fields.ino, 6) +
+    octal(fields.mode, 6) +
+    octal(fields.uid, 6) +
+    octal(fields.gid, 6) +
+    octal(fields.nlink, 6) +
+    octal(fields.rdev, 6) +
+    octal(fields.mtime, 11) +
+    octal(fields.namesize, 6) +
+    octal(fields.filesize, 11);
+  return Buffer.from(str, 'ascii');
+}
+
+export interface CpioWriteResult {
+  /** Total size of the uncompressed cpio stream. */
+  byteLength: number;
+  /** cksum CRC of each file's contents / symlink's target, keyed by path. */
+  checksums: Map<string, number>;
+  /** Summed Mach-O slice sizes per cpu type (for the BomInfo header). */
+  archSizes: Map<number, number>;
+  /** Total on-disk bytes of files identified as Mach-O. */
+  machOFileBytes: number;
+}
+
+/**
+ * Generate the cpio "odc" (portable ASCII) archive for a walked tree,
+ * byte-identical to the payload stream pkgbuild produces. Yields buffers;
+ * file contents are read lazily so only one read chunk is in flight at a
+ * time. CRC32 checksums (needed for the Bom) are computed during the single
+ * pass over file data and stored into `result.checksums`.
+ */
+export async function* cpioStream(
+  root: WalkEntry,
+  result: CpioWriteResult,
+): AsyncGenerator<Buffer> {
+  let ino = 0;
+  let written = 0;
+
+  const emit = (buf: Buffer): Buffer => {
+    written += buf.length;
+    return buf;
+  };
+
+  // 6-digit octal fields cap at 0o777777. The inode counter is synthetic and
+  // wraps like other cpio writers; uid/gid beyond the field (e.g. directory
+  // accounts on LDAP-bound machines) fall back to root, matching the
+  // ownership the payload records anyway.
+  const wrapIno = (value: number): number => value & 0o777777;
+  const clampId = (value: number): number => (value <= 0o777777 ? value : 0);
+
+  for (const entry of cpioOrder(root)) {
+    const nameBuf = Buffer.concat([Buffer.from(entry.path, 'utf8'), Buffer.from([0])]);
+    const isLink = entry.type === 'symlink';
+    const dataSize = entry.type === 'file' ? entry.size : isLink ? entry.size : 0;
+    yield emit(
+      header({
+        dev: 0,
+        ino: wrapIno(ino++),
+        mode: entry.mode,
+        uid: clampId(entry.uid),
+        gid: clampId(entry.gid),
+        nlink: clampId(entry.nlink),
+        rdev: 0,
+        mtime: entry.mtime,
+        namesize: nameBuf.length,
+        filesize: dataSize,
+      }),
+    );
+    yield emit(nameBuf);
+
+    if (isLink) {
+      const target = Buffer.from(entry.linkTarget ?? '', 'utf8');
+      result.checksums.set(entry.path, cksum(target));
+      yield emit(target);
+    } else if (entry.type === 'file') {
+      if (entry.size === 0) {
+        result.checksums.set(entry.path, cksumFinalize(0, 0));
+        continue;
+      }
+      const fh = await fs.promises.open(entry.sourcePath, 'r');
+      try {
+        let crc = 0;
+        let remaining = entry.size;
+        let first = true;
+        while (remaining > 0) {
+          const chunk = Buffer.allocUnsafe(Math.min(remaining, FILE_READ_CHUNK));
+          // Partial reads short of EOF are legal (network filesystems); keep
+          // reading until the chunk is full or the file truly ends early.
+          let filled = 0;
+          while (filled < chunk.length) {
+            const { bytesRead } = await fh.read(chunk, filled, chunk.length - filled);
+            if (bytesRead === 0) {
+              throw new Error(
+                `File changed while packaging: ${entry.sourcePath} (expected ${entry.size} bytes, hit end of file early)`,
+              );
+            }
+            filled += bytesRead;
+          }
+          if (first) {
+            first = false;
+            const slices = machOSliceSizes(chunk, entry.size);
+            if (slices) {
+              result.machOFileBytes += entry.size;
+              for (const [cpuType, size] of slices) {
+                result.archSizes.set(cpuType, (result.archSizes.get(cpuType) ?? 0) + size);
+              }
+            }
+          }
+          crc = cksumUpdate(crc, chunk);
+          remaining -= chunk.length;
+          yield emit(chunk);
+        }
+        result.checksums.set(entry.path, cksumFinalize(crc, entry.size));
+      } finally {
+        await fh.close();
+      }
+    }
+  }
+
+  // Trailer entry: the inode counter keeps running, everything else is zero.
+  const trailerName = Buffer.concat([Buffer.from(TRAILER_NAME, 'ascii'), Buffer.from([0])]);
+  yield emit(
+    header({
+      dev: 0,
+      ino: wrapIno(ino++),
+      mode: 0,
+      uid: 0,
+      gid: 0,
+      nlink: 1,
+      rdev: 0,
+      mtime: 0,
+      namesize: trailerName.length,
+      filesize: 0,
+    }),
+  );
+  yield emit(trailerName);
+
+  const padding = (BLOCK_SIZE - (written % BLOCK_SIZE)) % BLOCK_SIZE;
+  if (padding > 0) {
+    yield emit(Buffer.alloc(padding));
+  }
+  result.byteLength = written;
+}
+
+export function newCpioWriteResult(): CpioWriteResult {
+  return { byteLength: 0, checksums: new Map(), archSizes: new Map(), machOFileBytes: 0 };
+}

--- a/src/pkg-utils/distribution.ts
+++ b/src/pkg-utils/distribution.ts
@@ -1,0 +1,125 @@
+import { BundleInfo } from './package-info.js';
+import { escapeXml } from './xml.js';
+
+// RFC 3986 fragment characters productbuild leaves unencoded in the
+// trailing pkg-ref (#<name>): unreserved / sub-delims / ":" / "@" / "/" / "?".
+const FRAGMENT_ALLOWED = new Set(
+  Buffer.from(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~!$&'()*+,;=:@/?",
+    'ascii',
+  ),
+);
+
+/**
+ * Percent-encode an embedded package name the way productbuild does:
+ * Installer resolves the `#name.pkg` reference as a URL fragment.
+ */
+export function percentEncodeFragment(name: string): string {
+  const bytes = Buffer.from(name, 'utf8');
+  let out = '';
+  for (const byte of bytes) {
+    out += FRAGMENT_ALLOWED.has(byte)
+      ? String.fromCharCode(byte)
+      : `%${byte.toString(16).toUpperCase().padStart(2, '0')}`;
+  }
+  return out;
+}
+
+export interface DistributionOptions {
+  identifier: string;
+  /** Normalized package version, used in the trailing pkg-ref. */
+  version: string;
+  /** Emitted as the choice's customLocation; omitted when undefined. */
+  installLocation?: string;
+  installKBytes: number;
+  /** Name of the embedded component package, e.g. `com.example.app.pkg`. */
+  packageRef: string;
+  hostArchitectures: string;
+  bundle: BundleInfo;
+  /**
+   * Product style: `productbuild --component` emits `<product>`, `<title>`
+   * and titled choices; `productbuild --package` does not.
+   */
+  productStyle: boolean;
+  /** Title from CFBundleDisplayName/CFBundleName; omitted when the bundle has neither. */
+  title?: string;
+  /** Raw (unnormalized) CFBundleShortVersionString, used for product/versStr. */
+  rawShortVersion?: string;
+  /**
+   * The bundle's LSMinimumSystemVersion. When present productbuild emits a
+   * volume-check and bumps minSpecVersion to 2.
+   */
+  minimumSystemVersion?: string;
+}
+
+/**
+ * Render a Distribution document identical in shape to productbuild's
+ * output for the `--component` (productStyle) and `--package` invocations.
+ */
+export function renderDistribution(opts: DistributionOptions): string {
+  const id = escapeXml(opts.identifier);
+  const version = escapeXml(opts.version);
+  const bundleAttrs = [];
+  if (opts.bundle.shortVersionString !== undefined) {
+    bundleAttrs.push(`CFBundleShortVersionString="${escapeXml(opts.bundle.shortVersionString)}"`);
+  }
+  if (opts.bundle.bundleVersion !== undefined) {
+    bundleAttrs.push(`CFBundleVersion="${escapeXml(opts.bundle.bundleVersion)}"`);
+  }
+  bundleAttrs.push(`id="${escapeXml(opts.bundle.identifier)}"`);
+  bundleAttrs.push(`path="${escapeXml(opts.bundle.path)}"`);
+
+  const title = opts.title !== undefined ? escapeXml(opts.title) : undefined;
+  const titleAttr = title !== undefined ? ` title="${title}"` : '';
+  const versStrAttr =
+    opts.productStyle && opts.rawShortVersion !== undefined
+      ? ` versStr="${escapeXml(opts.rawShortVersion)}"`
+      : '';
+
+  const minimumSystemVersion = opts.productStyle ? opts.minimumSystemVersion : undefined;
+
+  let xml = '<?xml version="1.0" encoding="utf-8"?>\n';
+  xml += `<installer-gui-script minSpecVersion="${minimumSystemVersion !== undefined ? 2 : 1}">\n`;
+  xml += `    <pkg-ref id="${id}">\n`;
+  xml += '        <bundle-version>\n';
+  xml += `            <bundle ${bundleAttrs.join(' ')}/>\n`;
+  xml += '        </bundle-version>\n';
+  xml += '    </pkg-ref>\n';
+  if (opts.productStyle) {
+    xml +=
+      opts.rawShortVersion !== undefined
+        ? `    <product id="${id}" version="${escapeXml(opts.rawShortVersion)}"/>\n`
+        : `    <product id="${id}"/>\n`;
+    if (title !== undefined) {
+      xml += `    <title>${title}</title>\n`;
+    }
+  }
+  xml += `    <options customize="never" require-scripts="false" hostArchitectures="${escapeXml(opts.hostArchitectures)}"/>\n`;
+  if (minimumSystemVersion !== undefined) {
+    xml += '    <volume-check>\n';
+    xml += '        <allowed-os-versions>\n';
+    xml += `            <os-version min="${escapeXml(minimumSystemVersion)}"/>\n`;
+    xml += '        </allowed-os-versions>\n';
+    xml += '    </volume-check>\n';
+  }
+  xml += '    <choices-outline>\n';
+  xml += '        <line choice="default">\n';
+  xml += `            <line choice="${id}"/>\n`;
+  xml += '        </line>\n';
+  xml += '    </choices-outline>\n';
+  xml += `    <choice id="default"${titleAttr}${versStrAttr}/>\n`;
+  xml +=
+    `    <choice id="${id}"${titleAttr}` +
+    ' visible="false"' +
+    (opts.installLocation !== undefined
+      ? ` customLocation="${escapeXml(opts.installLocation)}"`
+      : '') +
+    '>\n';
+  xml += `        <pkg-ref id="${id}"/>\n`;
+  xml += '    </choice>\n';
+  xml +=
+    `    <pkg-ref id="${id}" version="${version}" onConclusion="none" ` +
+    `installKBytes="${opts.installKBytes}" updateKBytes="0">#${escapeXml(percentEncodeFragment(opts.packageRef))}</pkg-ref>\n`;
+  xml += '</installer-gui-script>';
+  return xml;
+}

--- a/src/pkg-utils/gzip.ts
+++ b/src/pkg-utils/gzip.ts
@@ -1,0 +1,130 @@
+import zlib from 'node:zlib';
+
+export interface GzipOptions {
+  /** zlib compression level (default 6, matching Apple's tools). */
+  level?: number;
+  /**
+   * 'parallel' (default): split the input into chunks compressed concurrently
+   * on the libuv threadpool as raw deflate segments terminated with a sync
+   * flush, then stitch them into a single standard gzip member (the same
+   * technique pigz uses). Output is a plain single-member gzip stream that
+   * every decoder — including macOS Installer's payload extractor, which
+   * rejects multi-member streams — accepts.
+   * 'single': one sequential deflate stream; slower, marginally better
+   * compression (the dictionary survives across chunk boundaries).
+   */
+  strategy?: 'parallel' | 'single';
+  /** Bytes per compression chunk in parallel mode. */
+  chunkSize?: number;
+  /** Maximum concurrent compression jobs in parallel mode. */
+  concurrency?: number;
+}
+
+const DEFAULT_CHUNK_SIZE = 2 * 1024 * 1024;
+
+function deflateRawChunk(chunk: Buffer, level: number): Promise<Buffer> {
+  // finishFlush: Z_SYNC_FLUSH ends the segment byte-aligned with an empty
+  // stored block and *without* a BFINAL marker, so segments concatenate into
+  // one valid deflate stream.
+  return new Promise((resolve, reject) => {
+    zlib.deflateRaw(chunk, { level, finishFlush: zlib.constants.Z_SYNC_FLUSH }, (err, out) =>
+      err ? reject(err) : resolve(out),
+    );
+  });
+}
+
+const GZIP_HEADER = Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03]);
+/** An empty final deflate block (BFINAL=1, static Huffman, end-of-block). */
+const FINAL_BLOCK = Buffer.from([0x03, 0x00]);
+
+/**
+ * Compress an async stream of buffers to a single-member gzip stream.
+ * Returns the ordered list of compressed buffers. In parallel mode,
+ * compression of earlier chunks overlaps with production (file reads) of
+ * later ones.
+ */
+export async function gzipStream(
+  source: AsyncIterable<Buffer>,
+  opts: GzipOptions = {},
+): Promise<Buffer[]> {
+  const level = opts.level ?? 6;
+  const strategy = opts.strategy ?? 'parallel';
+
+  if (strategy === 'single') {
+    const gz = zlib.createGzip({ level });
+    const out: Buffer[] = [];
+    gz.on('data', (d: Buffer) => out.push(d));
+    const done = new Promise<void>((resolve, reject) => {
+      gz.on('end', resolve);
+      gz.on('error', reject);
+    });
+    for await (const chunk of source) {
+      if (!gz.write(chunk)) {
+        await new Promise<void>((resolve) => gz.once('drain', resolve));
+      }
+    }
+    gz.end();
+    await done;
+    return out;
+  }
+
+  const chunkSize = opts.chunkSize ?? DEFAULT_CHUNK_SIZE;
+  const concurrency = opts.concurrency ?? 8;
+
+  const jobs: Promise<Buffer>[] = [];
+  let pending: Buffer[] = [];
+  let pendingSize = 0;
+  let crc = 0;
+  let totalSize = 0;
+  let inFlight = 0;
+  let release: (() => void) | null = null;
+
+  const flush = async () => {
+    if (pendingSize === 0) return;
+    const segment = pending.length === 1 ? pending[0] : Buffer.concat(pending);
+    pending = [];
+    pendingSize = 0;
+    crc = zlib.crc32(segment, crc) >>> 0;
+    totalSize += segment.length;
+    while (inFlight >= concurrency) {
+      await new Promise<void>((resolve) => {
+        release = resolve;
+      });
+    }
+    inFlight++;
+    const job = deflateRawChunk(segment, level).finally(() => {
+      inFlight--;
+      if (release) {
+        const r = release;
+        release = null;
+        r();
+      }
+    });
+    // A rejection must not become an unhandled rejection while the (possibly
+    // long) read loop is still producing; Promise.all below still observes
+    // the original promise.
+    job.catch(() => {});
+    jobs.push(job);
+  };
+
+  for await (const chunk of source) {
+    let offset = 0;
+    while (offset < chunk.length) {
+      const take = Math.min(chunk.length - offset, chunkSize - pendingSize);
+      pending.push(chunk.subarray(offset, offset + take));
+      pendingSize += take;
+      offset += take;
+      if (pendingSize >= chunkSize) {
+        await flush();
+      }
+    }
+  }
+  await flush();
+
+  const segments = await Promise.all(jobs);
+  const trailer = Buffer.alloc(10);
+  FINAL_BLOCK.copy(trailer, 0);
+  trailer.writeUInt32LE(crc >>> 0, 2);
+  trailer.writeUInt32LE(totalSize >>> 0, 6); // ISIZE is mod 2^32 per the spec
+  return [GZIP_HEADER, ...segments, trailer];
+}

--- a/src/pkg-utils/gzip.ts
+++ b/src/pkg-utils/gzip.ts
@@ -3,20 +3,9 @@ import zlib from 'node:zlib';
 export interface GzipOptions {
   /** zlib compression level (default 6, matching Apple's tools). */
   level?: number;
-  /**
-   * 'parallel' (default): split the input into chunks compressed concurrently
-   * on the libuv threadpool as raw deflate segments terminated with a sync
-   * flush, then stitch them into a single standard gzip member (the same
-   * technique pigz uses). Output is a plain single-member gzip stream that
-   * every decoder — including macOS Installer's payload extractor, which
-   * rejects multi-member streams — accepts.
-   * 'single': one sequential deflate stream; slower, marginally better
-   * compression (the dictionary survives across chunk boundaries).
-   */
-  strategy?: 'parallel' | 'single';
-  /** Bytes per compression chunk in parallel mode. */
+  /** Bytes per compression chunk. */
   chunkSize?: number;
-  /** Maximum concurrent compression jobs in parallel mode. */
+  /** Maximum concurrent compression jobs. */
   concurrency?: number;
 }
 
@@ -39,8 +28,12 @@ const FINAL_BLOCK = Buffer.from([0x03, 0x00]);
 
 /**
  * Compress an async stream of buffers to a single-member gzip stream.
- * Returns the ordered list of compressed buffers. In parallel mode,
- * compression of earlier chunks overlaps with production (file reads) of
+ * Returns the ordered list of compressed buffers. Chunks are compressed
+ * concurrently on the libuv threadpool as raw deflate segments terminated
+ * with a sync flush, then stitched into one standard gzip member (the same
+ * technique pigz uses) — macOS Installer's payload extractor rejects
+ * multi-member streams, so the framing must stay a plain single member.
+ * Compression of earlier chunks overlaps with production (file reads) of
  * later ones.
  */
 export async function gzipStream(
@@ -48,26 +41,6 @@ export async function gzipStream(
   opts: GzipOptions = {},
 ): Promise<Buffer[]> {
   const level = opts.level ?? 6;
-  const strategy = opts.strategy ?? 'parallel';
-
-  if (strategy === 'single') {
-    const gz = zlib.createGzip({ level });
-    const out: Buffer[] = [];
-    gz.on('data', (d: Buffer) => out.push(d));
-    const done = new Promise<void>((resolve, reject) => {
-      gz.on('end', resolve);
-      gz.on('error', reject);
-    });
-    for await (const chunk of source) {
-      if (!gz.write(chunk)) {
-        await new Promise<void>((resolve) => gz.once('drain', resolve));
-      }
-    }
-    gz.end();
-    await done;
-    return out;
-  }
-
   const chunkSize = opts.chunkSize ?? DEFAULT_CHUNK_SIZE;
   const concurrency = opts.concurrency ?? 8;
 

--- a/src/pkg-utils/macho.ts
+++ b/src/pkg-utils/macho.ts
@@ -1,0 +1,127 @@
+import fs from 'node:fs';
+
+/**
+ * Determine the host architectures productbuild advertises in the
+ * Distribution file by sniffing the app's main executable. Thin and fat
+ * Mach-O headers are supported; anything else falls back to the default
+ * productbuild uses ("x86_64,arm64", in that order).
+ */
+
+const FAT_MAGIC = 0xcafebabe;
+const FAT_MAGIC_64 = 0xcafebabf;
+const MH_MAGIC = 0xfeedface;
+const MH_MAGIC_64 = 0xfeedfacf;
+
+const CPU_ARCH_ABI64 = 0x01000000;
+const CPU_TYPE_X86 = 7;
+const CPU_TYPE_ARM = 12;
+
+export const DEFAULT_HOST_ARCHITECTURES = 'x86_64,arm64';
+
+const MH_CIGAM = 0xcefaedfe;
+const MH_CIGAM_64 = 0xcffaedfe;
+
+/**
+ * Per-architecture byte accounting for a file, used for the BomInfo header:
+ * mkbom records, per cpu type, the summed slice sizes of every Mach-O file
+ * (and everything else under cpu type 0).
+ */
+export function machOSliceSizes(header: Buffer, fileSize: number): Map<number, number> | null {
+  if (header.length < 8) return null;
+  const magicBE = header.readUInt32BE(0);
+  const sizes = new Map<number, number>();
+  if (magicBE === FAT_MAGIC || magicBE === FAT_MAGIC_64) {
+    const is64 = magicBE === FAT_MAGIC_64;
+    const count = header.readUInt32BE(4);
+    const entrySize = is64 ? 32 : 20;
+    if (count === 0 || count > 128 || header.length < 8 + count * entrySize) return null;
+    const headerEnd = 8 + count * entrySize;
+    for (let i = 0; i < count; i++) {
+      const base = 8 + i * entrySize;
+      const cpuType = header.readUInt32BE(base);
+      const offset = is64
+        ? Number(header.readBigUInt64BE(base + 8))
+        : header.readUInt32BE(base + 8);
+      const size = is64
+        ? Number(header.readBigUInt64BE(base + 16))
+        : header.readUInt32BE(base + 12);
+      // Bounds-sanity: every slice must live inside the file after the fat
+      // header. This rejects lookalikes such as Java .class files, which
+      // share the 0xCAFEBABE magic but carry garbage where the fat_arch
+      // table would be.
+      if (size === 0 || offset < headerEnd || offset + size > fileSize) return null;
+      sizes.set(cpuType, (sizes.get(cpuType) ?? 0) + size);
+    }
+    return sizes;
+  }
+  if (magicBE === MH_MAGIC || magicBE === MH_MAGIC_64) {
+    sizes.set(header.readUInt32BE(4), fileSize);
+    return sizes;
+  }
+  if (magicBE === MH_CIGAM || magicBE === MH_CIGAM_64) {
+    // Little-endian Mach-O read big-endian: cpu type is little-endian.
+    sizes.set(header.readUInt32LE(4), fileSize);
+    return sizes;
+  }
+  return null;
+}
+
+function cpuTypeName(cpuType: number): string | null {
+  switch (cpuType) {
+    case CPU_TYPE_X86 | CPU_ARCH_ABI64:
+      return 'x86_64';
+    case CPU_TYPE_ARM | CPU_ARCH_ABI64:
+      return 'arm64'; // arm64e is folded into arm64, matching productbuild
+    case CPU_TYPE_X86:
+      return 'i386';
+    case CPU_TYPE_ARM:
+      return 'arm';
+    default:
+      return null;
+  }
+}
+
+export async function readHostArchitectures(executablePath: string): Promise<string> {
+  let header: Buffer;
+  try {
+    const fh = await fs.promises.open(executablePath, 'r');
+    try {
+      header = Buffer.alloc(4096);
+      const { bytesRead } = await fh.read(header, 0, header.length, 0);
+      header = header.subarray(0, bytesRead);
+    } finally {
+      await fh.close();
+    }
+  } catch {
+    return DEFAULT_HOST_ARCHITECTURES;
+  }
+  if (header.length < 8) return DEFAULT_HOST_ARCHITECTURES;
+
+  const archs = new Set<string>();
+  const magicBE = header.readUInt32BE(0);
+
+  if (magicBE === FAT_MAGIC || magicBE === FAT_MAGIC_64) {
+    const is64 = magicBE === FAT_MAGIC_64;
+    const count = header.readUInt32BE(4);
+    const entrySize = is64 ? 32 : 20;
+    if (count > 128 || header.length < 8 + count * entrySize) {
+      return DEFAULT_HOST_ARCHITECTURES;
+    }
+    for (let i = 0; i < count; i++) {
+      const name = cpuTypeName(header.readUInt32BE(8 + i * entrySize));
+      if (name) archs.add(name);
+    }
+  } else {
+    const magicLE = header.readUInt32LE(0);
+    if (magicLE === MH_MAGIC || magicLE === MH_MAGIC_64) {
+      const name = cpuTypeName(header.readUInt32LE(4));
+      if (name) archs.add(name);
+    } else if (magicBE === MH_MAGIC || magicBE === MH_MAGIC_64) {
+      const name = cpuTypeName(header.readUInt32BE(4));
+      if (name) archs.add(name);
+    }
+  }
+
+  if (archs.size === 0) return DEFAULT_HOST_ARCHITECTURES;
+  return [...archs].sort().join(',');
+}

--- a/src/pkg-utils/package-info.ts
+++ b/src/pkg-utils/package-info.ts
@@ -1,0 +1,89 @@
+import { escapeXml } from './xml.js';
+
+export interface BundleInfo {
+  /** Bundle directory name, e.g. `App.app`. */
+  path: string;
+  identifier: string;
+  shortVersionString?: string;
+  bundleVersion?: string;
+}
+
+export interface PackageInfoOptions {
+  identifier: string;
+  version: string;
+  installLocation: string;
+  numberOfFiles: number;
+  installKBytes: number;
+  bundle: BundleInfo;
+  /** Names of scripts present in the Scripts archive. */
+  scripts?: { preinstall?: boolean; postinstall?: boolean };
+  /** Emitted by `productbuild --component`, absent from `pkgbuild` output. */
+  preserveXattr?: boolean;
+  /** Reported tool version, mirrors pkgbuild's generator-version attribute. */
+  generatorVersion?: string;
+}
+
+export const GENERATOR_VERSION = '@electron/osx-sign pkg-utils';
+
+/**
+ * Render a PackageInfo document identical in shape to the one pkgbuild
+ * emits (element order, attribute order, 4-space indent, no trailing
+ * newline).
+ */
+export function renderPackageInfo(opts: PackageInfoOptions): string {
+  const id = escapeXml(opts.identifier);
+  // Attribute-order quirk of pkgbuild: with a CFBundleVersion the path leads,
+  // without one it trails.
+  const bundleAttrs: string[] = [];
+  if (opts.bundle.bundleVersion !== undefined) {
+    bundleAttrs.push(`path="./${escapeXml(opts.bundle.path)}"`);
+    bundleAttrs.push(`id="${escapeXml(opts.bundle.identifier)}"`);
+    if (opts.bundle.shortVersionString !== undefined) {
+      bundleAttrs.push(`CFBundleShortVersionString="${escapeXml(opts.bundle.shortVersionString)}"`);
+    }
+    bundleAttrs.push(`CFBundleVersion="${escapeXml(opts.bundle.bundleVersion)}"`);
+  } else {
+    bundleAttrs.push(`id="${escapeXml(opts.bundle.identifier)}"`);
+    if (opts.bundle.shortVersionString !== undefined) {
+      bundleAttrs.push(`CFBundleShortVersionString="${escapeXml(opts.bundle.shortVersionString)}"`);
+    }
+    bundleAttrs.push(`path="./${escapeXml(opts.bundle.path)}"`);
+  }
+
+  let xml = '<?xml version="1.0" encoding="utf-8"?>\n';
+  xml +=
+    `<pkg-info overwrite-permissions="true" relocatable="false" identifier="${id}" ` +
+    `postinstall-action="none" version="${escapeXml(opts.version)}" format-version="2" ` +
+    `generator-version="${escapeXml(opts.generatorVersion ?? GENERATOR_VERSION)}" ` +
+    `install-location="${escapeXml(opts.installLocation)}" auth="root"` +
+    (opts.preserveXattr ? ' preserve-xattr="true"' : '') +
+    '>\n';
+  xml += `    <payload numberOfFiles="${opts.numberOfFiles}" installKBytes="${opts.installKBytes}"/>\n`;
+  xml += `    <bundle ${bundleAttrs.join(' ')}/>\n`;
+  xml += '    <bundle-version>\n';
+  xml += `        <bundle id="${id}"/>\n`;
+  xml += '    </bundle-version>\n';
+  xml += '    <upgrade-bundle>\n';
+  xml += `        <bundle id="${id}"/>\n`;
+  xml += '    </upgrade-bundle>\n';
+  xml += '    <update-bundle/>\n';
+  xml += '    <atomic-update-bundle/>\n';
+  xml += '    <strict-identifier>\n';
+  xml += `        <bundle id="${id}"/>\n`;
+  xml += '    </strict-identifier>\n';
+  xml += '    <relocate>\n';
+  xml += `        <bundle id="${id}"/>\n`;
+  xml += '    </relocate>\n';
+  if (opts.scripts && (opts.scripts.preinstall || opts.scripts.postinstall)) {
+    xml += '    <scripts>\n';
+    if (opts.scripts.preinstall) {
+      xml += '        <preinstall file="./preinstall" timeout="600"/>\n';
+    }
+    if (opts.scripts.postinstall) {
+      xml += '        <postinstall file="./postinstall" timeout="600"/>\n';
+    }
+    xml += '    </scripts>\n';
+  }
+  xml += '</pkg-info>';
+  return xml;
+}

--- a/src/pkg-utils/pkg.ts
+++ b/src/pkg-utils/pkg.ts
@@ -1,0 +1,432 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import plist from 'plist';
+
+import { walkTree, WalkOptions, cpioOrder, WalkEntry } from './walk.js';
+import { cpioStream, newCpioWriteResult } from './cpio-writer.js';
+import { gzipStream, GzipOptions } from './gzip.js';
+import { writeBom } from './bom-writer.js';
+import { BundleInfo, renderPackageInfo } from './package-info.js';
+import { renderDistribution } from './distribution.js';
+import { DEFAULT_HOST_ARCHITECTURES, readHostArchitectures } from './macho.js';
+import { readXar, writeXar, XarWriteFile } from './xar.js';
+import { findChild, parseXml } from './xml.js';
+import { debugLog } from '../util.js';
+
+const MAX_FILE_SIZE = 0xffffffff; // Bom stores 32-bit sizes; Size64 support is not implemented
+
+export interface ComponentPackageOptions {
+  /** Path to the bundle (.app) to package. */
+  app: string;
+  /** Install destination recorded in the package. Defaults to /Applications. */
+  installLocation?: string;
+  /** Package identifier. Defaults to the bundle's CFBundleIdentifier. */
+  identifier?: string;
+  /** Package version. Defaults to the bundle's CFBundleShortVersionString. */
+  version?: string;
+  /** Directory containing preinstall/postinstall scripts (pkgbuild --scripts). */
+  scripts?: string;
+  /** Compression settings for the payload. */
+  compression?: GzipOptions;
+  /** Rewrite entry ownership/permissions while packaging. */
+  transformEntry?: WalkOptions['transformEntry'];
+  /** Set the preserve-xattr PackageInfo attribute (productbuild --component). */
+  preserveXattr?: boolean;
+}
+
+export interface ComponentPackage {
+  identifier: string;
+  version: string;
+  installLocation: string;
+  numberOfFiles: number;
+  installKBytes: number;
+  hostArchitectures: string;
+  title?: string;
+  rawShortVersion?: string;
+  minimumSystemVersion?: string;
+  bundle: BundleInfo;
+  packageInfo: Buffer;
+  bom: Buffer;
+  payload: Buffer[];
+  scripts?: Buffer[];
+}
+
+interface AppMetadata {
+  identifier?: string;
+  shortVersionString?: string;
+  bundleVersion?: string;
+  name?: string;
+  displayName?: string;
+  executable?: string;
+  minimumSystemVersion?: string;
+}
+
+async function readAppMetadata(appPath: string): Promise<AppMetadata> {
+  const plistPath = path.join(appPath, 'Contents', 'Info.plist');
+  let raw: Buffer;
+  try {
+    raw = await fs.promises.readFile(plistPath);
+  } catch {
+    return {};
+  }
+  if (raw.subarray(0, 6).toString('ascii') === 'bplist') {
+    throw new Error(
+      `${plistPath} is a binary property list; only XML Info.plist files are supported`,
+    );
+  }
+  const parsed = plist.parse(raw.toString('utf8')) as Record<string, unknown>;
+  const str = (key: string): string | undefined =>
+    typeof parsed[key] === 'string' ? (parsed[key] as string) : undefined;
+  return {
+    identifier: str('CFBundleIdentifier'),
+    shortVersionString: str('CFBundleShortVersionString'),
+    bundleVersion: str('CFBundleVersion'),
+    name: str('CFBundleName'),
+    displayName: str('CFBundleDisplayName'),
+    executable: str('CFBundleExecutable'),
+    minimumSystemVersion: str('LSMinimumSystemVersion'),
+  };
+}
+
+/**
+ * pkgbuild normalizes dotted numeric versions to at least three components
+ * ("1.0" becomes "1.0.0"); anything else passes through unchanged.
+ */
+export function normalizePackageVersion(version: string): string {
+  if (!/^[0-9]+(\.[0-9]+)*$/.test(version)) return version;
+  const parts = version.split('.');
+  while (parts.length < 3) parts.push('0');
+  return parts.join('.');
+}
+
+function assertSizes(root: WalkEntry): void {
+  for (const entry of cpioOrder(root)) {
+    if (entry.type === 'file' && entry.size > MAX_FILE_SIZE) {
+      throw new Error(
+        `${entry.sourcePath} is larger than 4 GB, which flat packages cannot represent without Size64 support`,
+      );
+    }
+  }
+}
+
+/**
+ * Build a component package (the moral equivalent of `pkgbuild --component`)
+ * entirely in memory: payload cpio+gzip, Bom, and PackageInfo.
+ */
+export async function buildComponentPackage(
+  opts: ComponentPackageOptions,
+): Promise<ComponentPackage> {
+  const appPath = path.resolve(opts.app);
+  const installLocation = opts.installLocation ?? '/Applications';
+  const metadata = await readAppMetadata(appPath);
+
+  const identifier = opts.identifier ?? metadata.identifier;
+  if (!identifier) {
+    throw new Error(
+      `Cannot determine a package identifier: ${opts.app} has no CFBundleIdentifier and no identifier override was provided`,
+    );
+  }
+  const version = normalizePackageVersion(opts.version ?? metadata.shortVersionString ?? '0');
+
+  debugLog('pkg-utils: walking bundle...', appPath);
+  const root = await walkTree(appPath, {
+    transformEntry: opts.transformEntry,
+    rootStat: 'parent',
+    ownership: 'root',
+  });
+  assertSizes(root);
+
+  debugLog('pkg-utils: writing payload...');
+  const cpioResult = newCpioWriteResult();
+  const payload = await gzipStream(cpioStream(root, cpioResult), opts.compression);
+
+  debugLog('pkg-utils: writing Bom...');
+  const bom = writeBom(root, cpioResult.checksums, {
+    archSizes: cpioResult.archSizes,
+    machOFileBytes: cpioResult.machOFileBytes,
+  });
+
+  // numberOfFiles counts every node except the synthetic root; installKBytes
+  // is the Bom size total (root 0, directories 32 bytes per link) in KB.
+  let numberOfFiles = 0;
+  let sizeSum = 0;
+  for (const entry of cpioOrder(root)) {
+    if (entry.path === '.') continue;
+    numberOfFiles++;
+    sizeSum += entry.size;
+  }
+  const installKBytes = Math.floor(sizeSum / 1024);
+
+  let scripts: Buffer[] | undefined;
+  let scriptNames: { preinstall?: boolean; postinstall?: boolean } | undefined;
+  if (opts.scripts) {
+    debugLog('pkg-utils: writing scripts archive...', opts.scripts);
+    const scriptsRoot = await walkTree(path.resolve(opts.scripts), {
+      rootStat: 'self',
+      ownership: 'preserve',
+    });
+    const scriptsResult = newCpioWriteResult();
+    scripts = await gzipStream(cpioStream(scriptsRoot, scriptsResult), opts.compression);
+    // pkgbuild registers preinstall/postinstall whether they are regular
+    // files or symlinks to the real script.
+    const isScript = (c: { type: string }) => c.type === 'file' || c.type === 'symlink';
+    scriptNames = {
+      preinstall: scriptsRoot.children?.some((c) => c.name === 'preinstall' && isScript(c)),
+      postinstall: scriptsRoot.children?.some((c) => c.name === 'postinstall' && isScript(c)),
+    };
+  }
+
+  const bundleName = path.basename(appPath);
+  const bundle: BundleInfo = {
+    path: bundleName,
+    identifier,
+    shortVersionString: metadata.shortVersionString,
+    bundleVersion: metadata.bundleVersion,
+  };
+
+  let hostArchitectures = DEFAULT_HOST_ARCHITECTURES;
+  if (metadata.executable) {
+    hostArchitectures = await readHostArchitectures(
+      path.join(appPath, 'Contents', 'MacOS', metadata.executable),
+    );
+  }
+
+  const packageInfo = Buffer.from(
+    renderPackageInfo({
+      identifier,
+      version,
+      installLocation,
+      numberOfFiles,
+      installKBytes,
+      bundle,
+      scripts: scriptNames,
+      preserveXattr: opts.preserveXattr,
+    }),
+    'utf8',
+  );
+
+  return {
+    identifier,
+    version,
+    installLocation,
+    numberOfFiles,
+    installKBytes,
+    hostArchitectures,
+    title: metadata.displayName ?? metadata.name,
+    rawShortVersion: metadata.shortVersionString,
+    minimumSystemVersion: metadata.minimumSystemVersion,
+    bundle,
+    packageInfo,
+    bom,
+    payload,
+    scripts,
+  };
+}
+
+function componentXarFiles(component: ComponentPackage): XarWriteFile[] {
+  const files: XarWriteFile[] = [
+    { name: 'Bom', parts: [component.bom], compress: true },
+    { name: 'Payload', parts: component.payload },
+  ];
+  if (component.scripts) {
+    files.push({ name: 'Scripts', parts: component.scripts });
+  }
+  files.push({ name: 'PackageInfo', parts: [component.packageInfo], compress: true });
+  return files;
+}
+
+/**
+ * Write a standalone component package (.pkg), like `pkgbuild` does.
+ */
+export async function writeComponentPackage(
+  outputPath: string,
+  component: ComponentPackage,
+  opts: { creationTime?: Date } = {},
+): Promise<void> {
+  await writeXar(outputPath, componentXarFiles(component), opts);
+}
+
+export interface ProductArchiveOptions {
+  /** Output path for the product archive (.pkg). */
+  output: string;
+  /**
+   * Build the product from a bundle (`productbuild --component` semantics).
+   * Mutually exclusive with `package`.
+   */
+  app?: string;
+  /**
+   * Wrap an existing component package (`productbuild --package` semantics).
+   * Mutually exclusive with `app`.
+   */
+  package?: string;
+  installLocation?: string;
+  identifier?: string;
+  version?: string;
+  scripts?: string;
+  compression?: GzipOptions;
+  transformEntry?: WalkOptions['transformEntry'];
+  creationTime?: Date;
+  /**
+   * Only meaningful with `app`. When true (default) the archive matches
+   * `productbuild --component <app>`: preserve-xattr PackageInfo attribute,
+   * `<identifier>.pkg` embedded package name and a product-style Distribution
+   * with title/product elements. When false it matches the two-step
+   * `pkgbuild --component` + `productbuild --package` pipeline instead:
+   * plain PackageInfo, `<AppName>-component.pkg` embedded name and a
+   * package-style Distribution.
+   */
+  componentStyle?: boolean;
+}
+
+interface EmbeddedComponent {
+  /** Directory name of the embedded package inside the archive. */
+  name: string;
+  files: XarWriteFile[];
+  identifier: string;
+  version: string;
+  installLocation?: string;
+  installKBytes: number;
+  hostArchitectures: string;
+  bundle: BundleInfo;
+  productStyle: boolean;
+  title?: string;
+  rawShortVersion?: string;
+  minimumSystemVersion?: string;
+}
+
+async function embeddedFromPackageFile(packagePath: string): Promise<EmbeddedComponent> {
+  const members = await readXar(packagePath);
+  const packageInfoMember = members.find((m) => m.path === 'PackageInfo');
+  if (!packageInfoMember?.data) {
+    throw new Error(`${packagePath} is not a component package: missing PackageInfo`);
+  }
+  const info = parseXml(packageInfoMember.data.toString('utf8'));
+  if (info.name !== 'pkg-info') {
+    throw new Error(`${packagePath} has an invalid PackageInfo`);
+  }
+  const identifier = info.attributes.identifier;
+  const version = info.attributes.version ?? '0';
+  if (!identifier) {
+    throw new Error(`${packagePath}: PackageInfo has no identifier`);
+  }
+  const payloadElement = findChild(info, 'payload');
+  const installKBytes = Number(payloadElement?.attributes.installKBytes ?? '0');
+  const bundleElement = findChild(info, 'bundle');
+  const bundle: BundleInfo = bundleElement
+    ? {
+        path: (bundleElement.attributes.path ?? '').replace(/^\.\//, ''),
+        identifier: bundleElement.attributes.id ?? identifier,
+        shortVersionString: bundleElement.attributes.CFBundleShortVersionString,
+        bundleVersion: bundleElement.attributes.CFBundleVersion,
+      }
+    : { path: '', identifier };
+
+  const files: XarWriteFile[] = [];
+  for (const member of members) {
+    if (member.type !== 'file' || !member.data) continue;
+    // Re-encode the way the native tools store each member: Payload/Scripts
+    // are already gzip streams and stay raw, the rest are zlib-compressed.
+    const compress = member.path !== 'Payload' && member.path !== 'Scripts';
+    files.push({ name: member.path, parts: [member.data], compress });
+  }
+
+  return {
+    name: path.basename(packagePath),
+    files,
+    identifier,
+    version,
+    installKBytes,
+    // productbuild --package does not inspect the payload; it always
+    // advertises the default architecture list.
+    hostArchitectures: DEFAULT_HOST_ARCHITECTURES,
+    bundle,
+    productStyle: false,
+  };
+}
+
+/**
+ * Build a product archive — the JS equivalent of `productbuild --component`
+ * (pass `app`) or `productbuild --package` (pass `package`). The archive is
+ * unsigned; sign it afterwards with `productsign` if needed.
+ */
+export async function buildProductArchive(opts: ProductArchiveOptions): Promise<void> {
+  if ((opts.app ? 1 : 0) + (opts.package ? 1 : 0) !== 1) {
+    throw new Error('Specify exactly one of `app` or `package`');
+  }
+
+  let embedded: EmbeddedComponent;
+  if (opts.app) {
+    const componentStyle = opts.componentStyle ?? true;
+    const component = await buildComponentPackage({
+      app: opts.app,
+      installLocation: opts.installLocation,
+      identifier: opts.identifier,
+      version: opts.version,
+      scripts: opts.scripts,
+      compression: opts.compression,
+      transformEntry: opts.transformEntry,
+      preserveXattr: componentStyle,
+    });
+    embedded = {
+      name: componentStyle
+        ? `${component.identifier}.pkg`
+        : `${path.basename(path.resolve(opts.app), '.app')}-component.pkg`,
+      files: componentXarFiles(component),
+      identifier: component.identifier,
+      version: component.version,
+      installLocation: component.installLocation,
+      installKBytes: component.installKBytes,
+      // The two-step pipeline's productbuild step never sees the app, so it
+      // advertises the default architectures.
+      hostArchitectures: componentStyle ? component.hostArchitectures : DEFAULT_HOST_ARCHITECTURES,
+      bundle: component.bundle,
+      productStyle: componentStyle,
+      title: componentStyle ? component.title : undefined,
+      rawShortVersion: componentStyle ? component.rawShortVersion : undefined,
+      minimumSystemVersion: componentStyle ? component.minimumSystemVersion : undefined,
+    };
+  } else {
+    embedded = await embeddedFromPackageFile(opts.package!);
+    // In --package mode productbuild only records a customLocation when an
+    // install path is passed on the command line; the component's own
+    // install-location is not consulted.
+    embedded.installLocation = opts.installLocation;
+  }
+
+  const distribution = renderDistribution({
+    identifier: embedded.identifier,
+    version: embedded.version,
+    installLocation: embedded.installLocation,
+    installKBytes: embedded.installKBytes,
+    packageRef: embedded.name,
+    hostArchitectures: embedded.hostArchitectures,
+    bundle: embedded.bundle,
+    productStyle: embedded.productStyle,
+    title: embedded.title,
+    rawShortVersion: embedded.rawShortVersion,
+    minimumSystemVersion: embedded.minimumSystemVersion,
+  });
+
+  await writeXar(
+    opts.output,
+    [
+      { name: embedded.name, children: embedded.files },
+      { name: 'Distribution', parts: [Buffer.from(distribution, 'utf8')], compress: true },
+    ],
+    { creationTime: opts.creationTime },
+  );
+}
+
+/**
+ * Build a standalone component package on disk — the JS equivalent of
+ * `pkgbuild --component <app> [--scripts dir] [--install-location loc] out.pkg`.
+ */
+export async function buildComponentPackageFile(
+  outputPath: string,
+  opts: ComponentPackageOptions & { creationTime?: Date },
+): Promise<ComponentPackage> {
+  const component = await buildComponentPackage(opts);
+  await writeComponentPackage(outputPath, component, { creationTime: opts.creationTime });
+  return component;
+}

--- a/src/pkg-utils/walk.ts
+++ b/src/pkg-utils/walk.ts
@@ -1,0 +1,282 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * A single filesystem node captured during a package tree walk.
+ *
+ * Metadata mirrors what Apple's `pkgbuild` records: uid/gid are forced to
+ * root/wheel, directory `nlink`/`size` are derived from the child count (the
+ * values APFS reports) so that output is deterministic on every platform.
+ */
+export interface WalkEntry {
+  /** Archive-relative path, e.g. `.` or `./App.app/Contents` */
+  path: string;
+  /** Base name of the entry (`.` for the root). */
+  name: string;
+  type: 'file' | 'directory' | 'symlink';
+  /** Full st_mode including file-type bits. */
+  mode: number;
+  uid: number;
+  gid: number;
+  /** Whole seconds since the epoch. */
+  mtime: number;
+  /** File size in bytes; symlink target length; directory pseudo-size. */
+  size: number;
+  nlink: number;
+  /** Absolute path on disk (unset for the synthetic root). */
+  sourcePath: string;
+  /** Symlink target (symlinks only). */
+  linkTarget?: string;
+  /** Children in on-disk (readdir) order — the order pkgbuild archives them. */
+  children?: WalkEntry[];
+}
+
+export interface WalkOptions {
+  /**
+   * Rewrite ownership/permissions of an entry as it is recorded. Returning
+   * `undefined` keeps the entry unchanged. The file-type bits of `mode` are
+   * preserved automatically; only the permission bits of the returned mode are
+   * applied.
+   */
+  transformEntry?: (entry: {
+    path: string;
+    type: WalkEntry['type'];
+    mode: number;
+    uid: number;
+    gid: number;
+  }) => { mode?: number; uid?: number; gid?: number } | undefined;
+  /**
+   * How to derive the metadata of the synthetic root (`.`) entry:
+   * - 'parent': from the target directory's parent, like `pkgbuild --component`
+   *   records for the payload root.
+   * - 'self': from the target directory itself, like `pkgbuild --scripts`
+   *   records for the scripts archive root.
+   */
+  rootStat?: 'parent' | 'self';
+  /**
+   * Ownership to record: 'root' forces uid/gid to 0/0 like pkgbuild records
+   * payloads (--ownership recommended); 'preserve' keeps the on-disk uid/gid,
+   * which is what pkgbuild does for scripts archives.
+   */
+  ownership?: 'root' | 'preserve';
+}
+
+const S_IFMT = 0o170000;
+const S_IFDIR = 0o040000;
+const S_IFREG = 0o100000;
+const S_IFLNK = 0o120000;
+
+function mtimeSeconds(stat: fs.Stats): number {
+  return Math.max(0, Math.floor(stat.mtimeMs / 1000));
+}
+
+/**
+ * Walk `targetDir` and build the deterministic entry tree used to generate the
+ * payload cpio archive and the Bom. The traversal never follows symlinks.
+ */
+export async function walkTree(targetDir: string, opts: WalkOptions = {}): Promise<WalkEntry> {
+  const { transformEntry, rootStat = 'parent', ownership = 'root' } = opts;
+
+  const applyTransform = (entry: WalkEntry): WalkEntry => {
+    if (!transformEntry) return entry;
+    const patch = transformEntry({
+      path: entry.path,
+      type: entry.type,
+      mode: entry.mode,
+      uid: entry.uid,
+      gid: entry.gid,
+    });
+    if (!patch) return entry;
+    if (patch.mode !== undefined) {
+      entry.mode = (entry.mode & S_IFMT) | (patch.mode & 0o7777);
+    }
+    if (patch.uid !== undefined) entry.uid = patch.uid;
+    if (patch.gid !== undefined) entry.gid = patch.gid;
+    return entry;
+  };
+
+  const walkInto = async (absDir: string, relPath: string, dirEntry: WalkEntry): Promise<void> => {
+    // fs.opendir yields entries in raw filesystem order — the order pkgbuild
+    // archives them in. (fs.readdir would sort alphabetically.)
+    const dirents: fs.Dirent[] = [];
+    const dir = await fs.promises.opendir(absDir);
+    for await (const dirent of dir) {
+      dirents.push(dirent);
+    }
+    const children: WalkEntry[] = [];
+    for (const dirent of dirents) {
+      const abs = path.join(absDir, dirent.name);
+      const rel = `${relPath}/${dirent.name}`;
+      const stat = await fs.promises.lstat(abs);
+      if (stat.isDirectory()) {
+        const child = applyTransform({
+          path: rel,
+          name: dirent.name,
+          type: 'directory',
+          mode: (stat.mode & 0o7777) | S_IFDIR,
+          uid: ownership === 'preserve' ? stat.uid : 0,
+          gid: ownership === 'preserve' ? stat.gid : 0,
+          mtime: mtimeSeconds(stat),
+          size: 0,
+          nlink: 0,
+          sourcePath: abs,
+        });
+        await walkInto(abs, rel, child);
+        children.push(child);
+      } else if (stat.isFile()) {
+        children.push(
+          applyTransform({
+            path: rel,
+            name: dirent.name,
+            type: 'file',
+            mode: (stat.mode & 0o7777) | S_IFREG,
+            uid: ownership === 'preserve' ? stat.uid : 0,
+            gid: ownership === 'preserve' ? stat.gid : 0,
+            mtime: mtimeSeconds(stat),
+            size: stat.size,
+            nlink: 1,
+            sourcePath: abs,
+          }),
+        );
+      } else if (stat.isSymbolicLink()) {
+        const target = await fs.promises.readlink(abs);
+        children.push(
+          applyTransform({
+            path: rel,
+            name: dirent.name,
+            type: 'symlink',
+            mode: (stat.mode & 0o7777) | S_IFLNK,
+            uid: ownership === 'preserve' ? stat.uid : 0,
+            gid: ownership === 'preserve' ? stat.gid : 0,
+            mtime: mtimeSeconds(stat),
+            size: Buffer.byteLength(target),
+            nlink: 1,
+            sourcePath: abs,
+            linkTarget: target,
+          }),
+        );
+      } else {
+        throw new Error(
+          `Unsupported file type at ${abs}: only regular files, directories and symbolic links can be packaged`,
+        );
+      }
+    }
+    dirEntry.children = children;
+    // APFS reports st_nlink of a directory as 2 + number of children, and
+    // st_size as 32 bytes per link. Computing them keeps output identical
+    // across filesystems and platforms.
+    dirEntry.nlink = 2 + children.length;
+    dirEntry.size = 32 * dirEntry.nlink;
+  };
+
+  const targetStat = await fs.promises.lstat(targetDir);
+  if (!targetStat.isDirectory()) {
+    throw new Error(`Cannot package ${targetDir}: not a directory`);
+  }
+
+  let rootMode: number;
+  let rootMtime: number;
+  let rootNlinkBase: number;
+  if (rootStat === 'parent') {
+    // pkgbuild stamps the payload root with the stat of the directory that
+    // contains the bundle being packaged.
+    const parentDir = path.dirname(path.resolve(targetDir));
+    const parentStat = await fs.promises.lstat(parentDir);
+    rootMode = (parentStat.mode & 0o7777) | S_IFDIR;
+    rootMtime = mtimeSeconds(parentStat);
+    rootNlinkBase = 2 + (await fs.promises.readdir(parentDir)).length;
+  } else {
+    rootMode = (targetStat.mode & 0o7777) | S_IFDIR;
+    rootMtime = mtimeSeconds(targetStat);
+    rootNlinkBase = 0; // computed from children below
+  }
+
+  const root = applyTransform({
+    path: '.',
+    name: '.',
+    type: 'directory',
+    mode: rootMode,
+    uid: ownership === 'preserve' ? targetStat.uid : 0,
+    gid: ownership === 'preserve' ? targetStat.gid : 0,
+    mtime: rootMtime,
+    size: 0,
+    nlink: 0,
+    sourcePath: rootStat === 'self' ? targetDir : '',
+  });
+
+  if (rootStat === 'parent') {
+    root.sourcePath = '';
+    root.children = [];
+    // The payload root contains exactly the bundle. Walk the bundle itself as
+    // the single child of the synthetic root.
+    const bundleName = path.basename(path.resolve(targetDir));
+    const bundle = applyTransform({
+      path: `./${bundleName}`,
+      name: bundleName,
+      type: 'directory',
+      mode: (targetStat.mode & 0o7777) | S_IFDIR,
+      uid: ownership === 'preserve' ? targetStat.uid : 0,
+      gid: ownership === 'preserve' ? targetStat.gid : 0,
+      mtime: mtimeSeconds(targetStat),
+      size: 0,
+      nlink: 0,
+      sourcePath: path.resolve(targetDir),
+    });
+    await walkInto(path.resolve(targetDir), `./${bundleName}`, bundle);
+    root.children = [bundle];
+    root.nlink = rootNlinkBase;
+    root.size = 32 * root.nlink;
+  } else {
+    await walkInto(path.resolve(targetDir), '.', root);
+  }
+
+  return root;
+}
+
+/**
+ * Yield entries in the order pkgbuild writes them to the cpio payload:
+ * depth-first, directories before their contents, children in on-disk
+ * (readdir) order.
+ */
+export function* cpioOrder(root: WalkEntry): Generator<WalkEntry> {
+  function* visit(entry: WalkEntry): Generator<WalkEntry> {
+    yield entry;
+    if (entry.children) {
+      for (const child of entry.children) {
+        if (child.type === 'directory') {
+          yield* visit(child);
+        } else {
+          yield child;
+        }
+      }
+    }
+  }
+  yield* visit(root);
+}
+
+/**
+ * Name comparator used for Bom ordering: byte order of the NFD-normalized
+ * name. Apple's mkbom sorts with HFS+-style decomposed names ("é" orders as
+ * "e" + combining acute), while storing the raw name.
+ */
+export function bomNameCompare(a: string, b: string): number {
+  return Buffer.compare(Buffer.from(a.normalize('NFD')), Buffer.from(b.normalize('NFD')));
+}
+
+/**
+ * Yield entries in Bom id order: depth-first with children visited in
+ * decomposed-byte-lexicographic name order, matching Apple's mkbom id
+ * assignment.
+ */
+export function* bomOrder(root: WalkEntry): Generator<WalkEntry> {
+  function* visit(entry: WalkEntry): Generator<WalkEntry> {
+    yield entry;
+    if (entry.children) {
+      const sorted = [...entry.children].sort((a, b) => bomNameCompare(a.name, b.name));
+      for (const child of sorted) {
+        yield* visit(child);
+      }
+    }
+  }
+  yield* visit(root);
+}

--- a/src/pkg-utils/xar.ts
+++ b/src/pkg-utils/xar.ts
@@ -1,0 +1,250 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import zlib from 'node:zlib';
+
+import { escapeXml, findChild, findChildren, parseXml, XmlElement } from './xml.js';
+
+/**
+ * Minimal xar (eXtensible ARchiver) writer/reader covering what flat
+ * installer packages use: a zlib-compressed XML table of contents, a SHA-1
+ * heap checksum at offset 0, and file entries stored either raw
+ * (octet-stream) or zlib-compressed (application/x-gzip in xar parlance).
+ */
+
+const HEADER_SIZE = 28;
+const CHECKSUM_ALG_SHA1 = 1;
+
+export interface XarWriteFile {
+  name: string;
+  /** Present for directories. */
+  children?: XarWriteFile[];
+  /** File contents as one or more buffers (concatenated). */
+  parts?: Buffer[];
+  /**
+   * Compress the contents into the heap with zlib. Skip for data that is
+   * already compressed (e.g. gzip payloads), matching the native tools.
+   */
+  compress?: boolean;
+}
+
+interface PreparedFile {
+  id: number;
+  name: string;
+  children: PreparedFile[];
+  heap?: {
+    offset: number;
+    length: number;
+    size: number;
+    archivedChecksum: string;
+    extractedChecksum: string;
+    encoding: string;
+    parts: Buffer[];
+  };
+}
+
+function sha1(parts: Buffer[]): string {
+  const hash = crypto.createHash('sha1');
+  for (const part of parts) hash.update(part);
+  return hash.digest('hex');
+}
+
+function deflate(parts: Buffer[]): Buffer {
+  return zlib.deflateSync(parts.length === 1 ? parts[0] : Buffer.concat(parts));
+}
+
+function tocTimestamp(date: Date): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, '');
+}
+
+/**
+ * Serialize a xar archive to `outputPath`. Files are laid out in the heap in
+ * table-of-contents order, after the 20-byte TOC checksum at offset 0.
+ */
+export async function writeXar(
+  outputPath: string,
+  files: XarWriteFile[],
+  opts: { creationTime?: Date } = {},
+): Promise<void> {
+  let nextId = 1;
+  let heapOffset = 20; // TOC checksum occupies [0, 20)
+
+  const prepare = (file: XarWriteFile): PreparedFile => {
+    const prepared: PreparedFile = { id: nextId++, name: file.name, children: [] };
+    if (file.parts) {
+      const size = file.parts.reduce((sum, part) => sum + part.length, 0);
+      const extractedChecksum = sha1(file.parts);
+      let heapParts = file.parts;
+      let encoding = 'application/octet-stream';
+      let archivedChecksum = extractedChecksum;
+      if (file.compress) {
+        heapParts = [deflate(file.parts)];
+        encoding = 'application/x-gzip';
+        archivedChecksum = sha1(heapParts);
+      }
+      const length = heapParts.reduce((sum, part) => sum + part.length, 0);
+      prepared.heap = {
+        offset: heapOffset,
+        length,
+        size,
+        archivedChecksum,
+        extractedChecksum,
+        encoding,
+        parts: heapParts,
+      };
+      heapOffset += length;
+    } else {
+      prepared.children = (file.children ?? []).map(prepare);
+    }
+    return prepared;
+  };
+
+  const preparedFiles = files.map(prepare);
+
+  const renderFile = (file: PreparedFile, indent: string): string => {
+    let xml = `${indent}<file id="${file.id}">\n`;
+    xml += `${indent} <name>${escapeXml(file.name)}</name>\n`;
+    xml += `${indent} <type>${file.heap ? 'file' : 'directory'}</type>\n`;
+    if (file.heap) {
+      xml += `${indent} <data>\n`;
+      xml += `${indent}  <archived-checksum style="sha1">${file.heap.archivedChecksum}</archived-checksum>\n`;
+      xml += `${indent}  <extracted-checksum style="sha1">${file.heap.extractedChecksum}</extracted-checksum>\n`;
+      xml += `${indent}  <encoding style="${file.heap.encoding}"/>\n`;
+      xml += `${indent}  <size>${file.heap.size}</size>\n`;
+      xml += `${indent}  <offset>${file.heap.offset}</offset>\n`;
+      xml += `${indent}  <length>${file.heap.length}</length>\n`;
+      xml += `${indent} </data>\n`;
+    }
+    for (const child of file.children) {
+      xml += renderFile(child, indent + ' ');
+    }
+    xml += `${indent}</file>\n`;
+    return xml;
+  };
+
+  let toc = '<?xml version="1.0" encoding="UTF-8"?>\n<xar>\n <toc>\n';
+  toc += '  <checksum style="sha1">\n   <size>20</size>\n   <offset>0</offset>\n  </checksum>\n';
+  toc += `  <creation-time>${tocTimestamp(opts.creationTime ?? new Date())}</creation-time>\n`;
+  for (const file of preparedFiles) {
+    toc += renderFile(file, '  ');
+  }
+  toc += ' </toc>\n</xar>\n';
+
+  const tocRaw = Buffer.from(toc, 'utf8');
+  const tocCompressed = zlib.deflateSync(tocRaw);
+  const tocChecksum = crypto.createHash('sha1').update(tocCompressed).digest();
+
+  const header = Buffer.alloc(HEADER_SIZE);
+  header.write('xar!', 0, 'ascii');
+  header.writeUInt16BE(HEADER_SIZE, 4);
+  header.writeUInt16BE(1, 6);
+  header.writeBigUInt64BE(BigInt(tocCompressed.length), 8);
+  header.writeBigUInt64BE(BigInt(tocRaw.length), 16);
+  header.writeUInt32BE(CHECKSUM_ALG_SHA1, 24);
+
+  const stream = fs.createWriteStream(outputPath);
+  // Capture stream-level errors (ENOENT on the directory, ENOSPC, ...): they
+  // are emitted as 'error' events, which would otherwise crash the process.
+  let streamError: Error | null = null;
+  const errorListener = (err: Error) => {
+    streamError = streamError ?? err;
+  };
+  stream.on('error', errorListener);
+  const write = (chunk: Buffer): Promise<void> =>
+    new Promise((resolve, reject) => {
+      if (streamError) {
+        reject(streamError);
+        return;
+      }
+      stream.write(chunk, (err) => (err ? reject(err) : resolve()));
+    });
+
+  try {
+    await write(header);
+    await write(tocCompressed);
+    await write(tocChecksum);
+    const writeHeap = async (file: PreparedFile): Promise<void> => {
+      if (file.heap) {
+        for (const part of file.heap.parts) {
+          await write(part);
+        }
+      }
+      for (const child of file.children) {
+        await writeHeap(child);
+      }
+    };
+    for (const file of preparedFiles) {
+      await writeHeap(file);
+    }
+  } finally {
+    await new Promise<void>((resolve) => {
+      stream.end(() => resolve());
+    });
+  }
+  if (streamError) {
+    throw streamError;
+  }
+}
+
+export interface XarReadFile {
+  /** Path within the archive, e.g. `component.pkg/PackageInfo`. */
+  path: string;
+  type: 'file' | 'directory';
+  /** Decompressed contents (files only). */
+  data?: Buffer;
+}
+
+/** Read a xar archive fully into memory, decompressing each member. */
+export async function readXar(archivePath: string): Promise<XarReadFile[]> {
+  const data = await fs.promises.readFile(archivePath);
+  if (data.length < HEADER_SIZE || data.toString('ascii', 0, 4) !== 'xar!') {
+    throw new Error(`${archivePath} is not a xar archive`);
+  }
+  const headerSize = data.readUInt16BE(4);
+  const tocCompressedLength = Number(data.readBigUInt64BE(8));
+  const heapStart = headerSize + tocCompressedLength;
+  const toc = zlib.inflateSync(data.subarray(headerSize, heapStart)).toString('utf8');
+
+  const root = parseXml(toc);
+  const tocElement = findChild(root, 'toc');
+  if (!tocElement) throw new Error(`${archivePath}: xar TOC is missing <toc>`);
+
+  const results: XarReadFile[] = [];
+  const visit = (element: XmlElement, prefix: string): void => {
+    for (const file of findChildren(element, 'file')) {
+      const name = findChild(file, 'name')?.text ?? '';
+      const type = findChild(file, 'type')?.text === 'directory' ? 'directory' : 'file';
+      const filePath = prefix ? `${prefix}/${name}` : name;
+      if (type === 'directory') {
+        results.push({ path: filePath, type });
+        visit(file, filePath);
+        continue;
+      }
+      const dataElement = findChild(file, 'data');
+      if (!dataElement) {
+        results.push({ path: filePath, type, data: Buffer.alloc(0) });
+        continue;
+      }
+      const offset = Number(findChild(dataElement, 'offset')?.text ?? 'NaN');
+      const length = Number(findChild(dataElement, 'length')?.text ?? 'NaN');
+      if (!Number.isFinite(offset) || !Number.isFinite(length)) {
+        throw new Error(`${archivePath}: invalid data offsets for ${filePath}`);
+      }
+      const raw = data.subarray(heapStart + offset, heapStart + offset + length);
+      const encoding =
+        findChild(dataElement, 'encoding')?.attributes.style ?? 'application/octet-stream';
+      let contents: Buffer;
+      if (encoding === 'application/octet-stream') {
+        contents = Buffer.from(raw);
+      } else if (encoding === 'application/x-gzip') {
+        contents = zlib.inflateSync(raw);
+      } else if (encoding === 'application/x-bzip2') {
+        throw new Error(`${archivePath}: bzip2-encoded xar members are not supported`);
+      } else {
+        throw new Error(`${archivePath}: unsupported xar encoding ${encoding}`);
+      }
+      results.push({ path: filePath, type, data: contents });
+    }
+  };
+  visit(tocElement, '');
+  return results;
+}

--- a/src/pkg-utils/xml.ts
+++ b/src/pkg-utils/xml.ts
@@ -1,0 +1,143 @@
+/**
+ * Small XML helpers for the machine-generated documents inside flat packages
+ * (PackageInfo, Distribution, xar table of contents). Not a general-purpose
+ * XML library.
+ */
+
+export function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+export interface XmlElement {
+  name: string;
+  attributes: Record<string, string>;
+  children: XmlElement[];
+  text: string;
+}
+
+function unescapeXml(value: string): string {
+  return value.replace(/&(amp|lt|gt|quot|apos|#x?[0-9a-fA-F]+);/g, (_, entity: string) => {
+    switch (entity) {
+      case 'amp':
+        return '&';
+      case 'lt':
+        return '<';
+      case 'gt':
+        return '>';
+      case 'quot':
+        return '"';
+      case 'apos':
+        return "'";
+      default:
+        return String.fromCodePoint(
+          entity[1] === 'x' || entity[1] === 'X'
+            ? parseInt(entity.slice(2), 16)
+            : parseInt(entity.slice(1), 10),
+        );
+    }
+  });
+}
+
+/**
+ * Parse a well-formed XML document into a simple element tree. Supports what
+ * appears in xar TOCs and PackageInfo files: elements, attributes, character
+ * data, comments, processing instructions and doctypes (both skipped).
+ */
+export function parseXml(input: string): XmlElement {
+  let pos = 0;
+  const len = input.length;
+
+  const error = (message: string): never => {
+    throw new Error(`XML parse error at offset ${pos}: ${message}`);
+  };
+
+  const skipMisc = () => {
+    for (;;) {
+      while (pos < len && /\s/.test(input[pos])) pos++;
+      if (input.startsWith('<?', pos)) {
+        const end = input.indexOf('?>', pos);
+        if (end === -1) error('unterminated processing instruction');
+        pos = end + 2;
+      } else if (input.startsWith('<!--', pos)) {
+        const end = input.indexOf('-->', pos);
+        if (end === -1) error('unterminated comment');
+        pos = end + 3;
+      } else if (input.startsWith('<!', pos)) {
+        const end = input.indexOf('>', pos);
+        if (end === -1) error('unterminated declaration');
+        pos = end + 1;
+      } else {
+        return;
+      }
+    }
+  };
+
+  const parseElement = (): XmlElement => {
+    if (input[pos] !== '<') error('expected element');
+    pos++;
+    const nameMatch = /^[^\s/>]+/.exec(input.slice(pos));
+    if (!nameMatch) error('expected element name');
+    const name = nameMatch![0];
+    pos += name.length;
+    const element: XmlElement = { name, attributes: {}, children: [], text: '' };
+
+    for (;;) {
+      while (pos < len && /\s/.test(input[pos])) pos++;
+      if (input.startsWith('/>', pos)) {
+        pos += 2;
+        return element;
+      }
+      if (input[pos] === '>') {
+        pos++;
+        break;
+      }
+      const attrMatch = /^([^\s=/>]+)\s*=\s*("([^"]*)"|'([^']*)')/.exec(input.slice(pos));
+      if (!attrMatch) error('expected attribute');
+      element.attributes[attrMatch![1]] = unescapeXml(attrMatch![3] ?? attrMatch![4] ?? '');
+      pos += attrMatch![0].length;
+    }
+
+    // Content
+    for (;;) {
+      if (pos >= len) error(`unterminated element <${name}>`);
+      if (input.startsWith('</', pos)) {
+        const end = input.indexOf('>', pos);
+        if (end === -1) error('unterminated closing tag');
+        const closing = input.slice(pos + 2, end).trim();
+        if (closing !== name) error(`mismatched closing tag ${closing}, expected ${name}`);
+        pos = end + 1;
+        return element;
+      }
+      if (input.startsWith('<!--', pos)) {
+        const end = input.indexOf('-->', pos);
+        if (end === -1) error('unterminated comment');
+        pos = end + 3;
+        continue;
+      }
+      if (input[pos] === '<') {
+        element.children.push(parseElement());
+        continue;
+      }
+      const next = input.indexOf('<', pos);
+      const textEnd = next === -1 ? len : next;
+      element.text += unescapeXml(input.slice(pos, textEnd));
+      pos = textEnd;
+    }
+  };
+
+  skipMisc();
+  const rootElement = parseElement();
+  return rootElement;
+}
+
+export function findChild(element: XmlElement, name: string): XmlElement | undefined {
+  return element.children.find((child) => child.name === name);
+}
+
+export function findChildren(element: XmlElement, name: string): XmlElement[] {
+  return element.children.filter((child) => child.name === name);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,6 +269,18 @@ type OnlyFlatOptions = {
    * @defaultValue `false`
    */
   openPermissionsForSquirrelMac?: boolean;
+  /**
+   * Which packaging implementation builds the `.pkg`:
+   *
+   * - `'native'` shells out to Apple's `pkgbuild`/`productbuild` binaries.
+   * - `'js'` builds the flat package with the bundled pure-JavaScript
+   *   implementation — substantially faster and usable on any platform.
+   *   When an {@link BaseSignOptions.identity | identity} is provided the
+   *   built package is signed with `productsign` (macOS only).
+   *
+   * @defaultValue `"native"`
+   */
+  implementation?: 'native' | 'js';
 };
 
 type OnlyValidatedFlatOptions = {


### PR DESCRIPTION
Adds an opt-in `implementation: 'js'` option to `flat()` (and `--implementation=js` on the CLI) that builds `.pkg` installers with a bundled pure-JavaScript implementation of the flat package format instead of shelling out to `pkgbuild`/`productbuild`.

## Performance

~4.5x faster on a real Electron.app, measured with the included `yarn bench` (Electron v35.0.3, 244 MB, darwin-arm64):

| pipeline | median | speedup | output size |
| --- | --- | --- | --- |
| native `pkgbuild` + `productbuild --package` | 6.11s | 1.00x | 105.5 MB |
| native `productbuild --component` (MAS) | 5.90s | 1.04x | 105.5 MB |
| js implementation | 1.35s | 4.53x | 108.7 MB |

The win comes from doing everything in a single pass (no intermediate component pkg on disk, no re-reading it) and compressing the payload in parallel on the libuv threadpool — sync-flushed deflate segments stitched into a single standard gzip member, pigz-style, since Installer rejects multi-member gzip. The benchmark byte-verifies the JS payload against the native payload before reporting. Unsigned packages can also now be built on any platform; signing is delegated to `productsign` when an identity is provided.

## Correctness

The implementation covers the whole stack — cpio payload, Bom (BOMStore binary format), PackageInfo/Distribution, and the outer xar — and `spec/pkg-utils/` verifies parity against Apple's tools on macOS:

- Uncompressed payload cpio streams are **byte-identical** to `pkgbuild`'s, across a fixture matrix (symlinks, empty dirs, odd modes, unicode/sort-hostile names, scripts, multi-leaf bom trees) and a real downloaded Electron.app.
- `lsbom` output is identical on every printable field, plus identical BomInfo size accounting (including per-architecture Mach-O slice sums) and B-tree entry ordering.
- PackageInfo/Distribution are byte-identical modulo the `generator-version` attribute, including version normalization, title/versStr rules, `LSMinimumSystemVersion` volume-checks and percent-encoded package references.
- `pkgutil --expand-full` expands the JS-built package back to a tree identical to the source app.
- Cross-platform unit tests cover each format layer without needing the native tools.

Intentional differences are documented in the README (no xattr/AppleDouble preservation, XML `Info.plist` only, 4 GB per-file cap, hardlinks stored as copies, ~3% larger compressed output). Two native quirks are deliberately not reproduced: `pkgbuild` silently drops NFC-normalized filenames from the payload, and emits an empty payload for bundle names containing a spaced em dash — the JS implementation packages both correctly, with a regression test for the former.

The default remains `'native'`; existing behavior (including the `openPermissionsForSquirrelMac` bom/cpio rewrite path) is untouched.